### PR TITLE
Integrate certificatetpr into operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Download the latest docker image from here: https://hub.docker.com/r/giantswarm/
 #### Dependencies
 
 - [github.com/giantswarm/microkit](https://github.com/giantswarm/microkit)
+- [github.com/giantswarm/certificatetpr](https://github.com/giantswarm/certificatetpr)
 
 #### Building the standard way
 

--- a/client/k8s/decoder.go
+++ b/client/k8s/decoder.go
@@ -1,0 +1,32 @@
+package k8s
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/giantswarm/certificatetpr"
+	"k8s.io/client-go/pkg/runtime"
+	"k8s.io/client-go/pkg/watch"
+)
+
+type CertificateDecoder struct {
+	Stream io.ReadCloser
+}
+
+// Decode deserializes a runtime object into a certificatetpr CustomObject.
+func (d *CertificateDecoder) Decode() (action watch.EventType, object runtime.Object, err error) {
+	decoder := json.NewDecoder(d.Stream)
+
+	var e struct {
+		Type   watch.EventType
+		Object certificatetpr.CustomObject
+	}
+	if err := decoder.Decode(&e); err != nil {
+		return watch.Error, nil, err
+	}
+	return e.Type, &e.Object, nil
+}
+
+func (d *CertificateDecoder) Close() {
+	d.Stream.Close()
+}

--- a/examples/example-cert.yaml
+++ b/examples/example-cert.yaml
@@ -7,9 +7,8 @@ spec:
   commonName: "api.cert-test.g8s.eu-west-1.aws.test.private.giantswarm.io"
   altNames:
   - "cert-test.g8s.eu-west-1.aws.test.private.giantswarm.io"
-  # TODO Fix bug with allowing bare domains
-  # - "k8s-master-vm"
-  # - "kubernetes"
+  - "k8s-master-vm"
+  - "kubernetes"
   - "kubernetes.default"
   - "kubernetes.default.svc"
   - "kubernetes.default.svc.cluster.local"

--- a/examples/example-cert.yaml
+++ b/examples/example-cert.yaml
@@ -1,0 +1,20 @@
+apiVersion: "giantswarm.io/v1"
+kind: Certificate
+metadata:
+  name: "example-cert"
+spec:
+  clusterID: "cert-test"
+  commonName: "api.cert-test.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  altNames:
+  - "cert-test.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  # TODO Fix bug with allowing bare domains
+  # - "k8s-master-vm"
+  # - "kubernetes"
+  - "kubernetes.default"
+  - "kubernetes.default.svc"
+  - "kubernetes.default.svc.cluster.local"
+  ipSans:
+  - "10.0.2.1"
+  - "10.0.2.2"
+  ttl: "720h"
+  allowBareDomains: true

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: bd3bb558eb767c022c08b6ca20b7733673f5e920f77cbdfcec9b99c2881a479a
-updated: 2017-03-22T20:35:35.463796756+01:00
+hash: b0565c64180d64944fd4aef93db887765fd070c527ab8f60a2c08d9efe823238
+updated: 2017-03-23T12:56:45.112810719+01:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -65,6 +65,8 @@ imports:
   - service/pki
   - service/spec
   - service/token
+- name: github.com/giantswarm/certificatetpr
+  version: 42a7d2d2af0b2f8bb375a46134111211f0345ba7
 - name: github.com/giantswarm/go-uuid
   version: ed3ca8a15a931b141440a7e98e4f716eec255f7d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -26,12 +26,15 @@ import:
   subpackages:
   - api
 - package: github.com/juju/errgo
-- package: golang.org/x/net/context
+- package: golang.org/x/net
+  subpackages:
+  - context
 - package: k8s.io/client-go
   version: ^2.0.0
   subpackages:
   - kubernetes
   - rest
+- package: github.com/giantswarm/certificatetpr
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/service/create/cert_signer.go
+++ b/service/create/cert_signer.go
@@ -5,12 +5,13 @@ import (
 
 	"github.com/giantswarm/certctl/service/cert-signer"
 	"github.com/giantswarm/certctl/service/spec"
+	"github.com/giantswarm/certificatetpr"
 	microerror "github.com/giantswarm/microkit/error"
 )
 
 // Issue generates a certificate using the PKI backend signed by the certificate
 // authority associated with the configured cluster ID.
-func (s *Service) Issue(config CertificateSpec) (spec.IssueResponse, error) {
+func (s *Service) Issue(cert certificatetpr.Spec) (spec.IssueResponse, error) {
 	var issueResp spec.IssueResponse
 
 	// Create a certificate signer to generate a new signed certificate.
@@ -24,11 +25,11 @@ func (s *Service) Issue(config CertificateSpec) (spec.IssueResponse, error) {
 
 	// Generate a new signed certificate.
 	newIssueConfig := spec.IssueConfig{
-		ClusterID:  config.ClusterID,
-		CommonName: config.CommonName,
-		IPSANs:     strings.Join(config.IPSANs, ","),
-		AltNames:   strings.Join(config.AltNames, ","),
-		TTL:        config.TTL,
+		ClusterID:  cert.ClusterID,
+		CommonName: cert.CommonName,
+		IPSANs:     strings.Join(cert.IPSANs, ","),
+		AltNames:   strings.Join(cert.AltNames, ","),
+		TTL:        cert.TTL,
 	}
 
 	newIssueResponse, err := newCertSigner.Issue(newIssueConfig)

--- a/service/create/pki.go
+++ b/service/create/pki.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"strings"
 
-	microerror "github.com/giantswarm/microkit/error"
-
 	"github.com/giantswarm/certctl/service/pki"
 	"github.com/giantswarm/certctl/service/token"
+	"github.com/giantswarm/certificatetpr"
+	microerror "github.com/giantswarm/microkit/error"
 )
 
 // setupPKIBackend creates a PKI backend if one does not exist for the cluster.
-func (s *Service) setupPKIBackend(cert CertificateSpec) error {
+func (s *Service) setupPKIBackend(cert certificatetpr.Spec) error {
 	var err error
 
 	service, err := s.getPKIService()
@@ -44,7 +44,7 @@ func (s *Service) setupPKIBackend(cert CertificateSpec) error {
 }
 
 // setupPKIPolicy creates a PKI policy if one does not exist for the cluster.
-func (s *Service) setupPKIPolicy(cert CertificateSpec) error {
+func (s *Service) setupPKIPolicy(cert certificatetpr.Spec) error {
 	var err error
 
 	service, err := s.getTokenService()
@@ -65,14 +65,14 @@ func (s *Service) setupPKIPolicy(cert CertificateSpec) error {
 	return service.CreatePolicy(cert.ClusterID)
 }
 
-func (config Config) getCACommonName(cert CertificateSpec) string {
+func (config Config) getCACommonName(cert certificatetpr.Spec) string {
 	commonNameFormat := config.Viper.GetString(config.Flag.Vault.PKI.CommonNameFormat)
 	commonName := fmt.Sprintf(commonNameFormat, cert.ClusterID)
 
 	return commonName
 }
 
-func getAllowedDomainsForCA(caCommonName string, cert CertificateSpec) string {
+func getAllowedDomainsForCA(caCommonName string, cert certificatetpr.Spec) string {
 	domains := []string{caCommonName}
 	domains = append(domains, cert.AltNames...)
 

--- a/service/create/pki_test.go
+++ b/service/create/pki_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/giantswarm/certificatetpr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,13 +13,13 @@ func TestGetAllowedDomainsForCA(t *testing.T) {
 	tests := []struct {
 		name                string
 		caCommonName        string
-		cert                CertificateSpec
+		cert                certificatetpr.Spec
 		expectedDomainCount int
 	}{
 		{
 			name:         "Specify api cert with alt names",
 			caCommonName: "cluster-test.g8s.test.giantswarm.io",
-			cert: CertificateSpec{
+			cert: certificatetpr.Spec{
 				AltNames: []string{
 					"kubernetes",
 					"kubernetes.default",
@@ -31,7 +32,7 @@ func TestGetAllowedDomainsForCA(t *testing.T) {
 		{
 			name:                "Specify etcd cert without alt names",
 			caCommonName:        "cluster-test.g8s.test.giantswarm.io",
-			cert:                CertificateSpec{},
+			cert:                certificatetpr.Spec{},
 			expectedDomainCount: 1,
 		},
 	}

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -14,16 +14,6 @@ import (
 	"github.com/giantswarm/cert-operator/flag"
 )
 
-// TODO Replace with Certificate TPR
-type CertificateSpec struct {
-	ClusterID        string
-	CommonName       string
-	IPSANs           []string
-	AltNames         []string
-	AllowBareDomains bool
-	TTL              string
-}
-
 // Config represents the configuration used to create a create service.
 type Config struct {
 	// Dependencies.
@@ -98,7 +88,7 @@ func (s *Service) Boot() {
 		}
 		s.Config.Logger.Log("info", "successfully created third-party resource")
 
-		cert := CertificateSpec{
+		cert := certificatetpr.Spec{
 			ClusterID:  "cert-test",
 			CommonName: "api.cert-test.g8s.eu-west-1.aws.test.private.giantswarm.io",
 			IPSANs:     []string{"10.0.0.4", "10.0.0.5"},

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/giantswarm/certificatetpr"
 	microerror "github.com/giantswarm/microkit/error"
 	micrologger "github.com/giantswarm/microkit/logger"
 	vaultapi "github.com/hashicorp/vault/api"
@@ -92,7 +93,10 @@ type Service struct {
 // Boot starts the service
 func (s *Service) Boot() {
 	s.bootOnce.Do(func() {
-		s.Config.Logger.Log("info", "Booted cert-operator")
+		if err := s.createTPR(); err != nil {
+			panic(fmt.Sprintf("could not create cluster resource: %#v", err))
+		}
+		s.Config.Logger.Log("info", "successfully created third-party resource")
 
 		cert := CertificateSpec{
 			ClusterID:  "cert-test",

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -109,9 +109,9 @@ func (s *Service) Boot() {
 			&certificatetpr.CustomObject{},
 			resyncPeriod,
 			cache.ResourceEventHandlerFuncs{
-				AddFunc:    s.handleCertAdd,
-				DeleteFunc: s.handleCertDelete,
-				UpdateFunc: s.handleCertUpdate,
+				AddFunc:    s.addFunc,
+				DeleteFunc: s.deleteFunc,
+				UpdateFunc: s.updateFunc,
 			},
 		)
 
@@ -123,9 +123,9 @@ func (s *Service) Boot() {
 	})
 }
 
-// handleCertAdd issues a certificate using Vault for the certificate TPR. A PKI backend is
+// addFunc issues a certificate using Vault for the certificate TPR. A PKI backend is
 // setup for the Cluster ID if it does not yet exist.
-func (s *Service) handleCertAdd(obj interface{}) {
+func (s *Service) addFunc(obj interface{}) {
 	cert := obj.(*certificatetpr.CustomObject)
 	s.Config.Logger.Log("info", fmt.Sprintf("creating certificate '%s'", cert.Spec.CommonName))
 
@@ -146,14 +146,14 @@ func (s *Service) handleCertAdd(obj interface{}) {
 	s.Config.Logger.Log("info", fmt.Sprintf("certificate issued %s", cert.Spec.CommonName))
 }
 
-// handleCertDelete is not yet implemented.
-func (s *Service) handleCertDelete(obj interface{}) {
+// deleteFunc is not yet implemented.
+func (s *Service) deleteFunc(obj interface{}) {
 	cert := obj.(*certificatetpr.CustomObject)
 	s.Config.Logger.Log("info", fmt.Sprintf("deleting certificate '%s' is not implemented yet", cert.Spec.CommonName))
 }
 
-// handleCertUpdate is not yet implemented.
-func (s *Service) handleCertUpdate(old, cur interface{}) {
+// updateFunc is not yet implemented.
+func (s *Service) updateFunc(old, cur interface{}) {
 	cert := cur.(*certificatetpr.CustomObject)
 	s.Config.Logger.Log("info", fmt.Sprintf("updating certificate '%s' is not implemented yet", cert.Spec.CommonName))
 }

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -1,8 +1,10 @@
 package create
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/giantswarm/certificatetpr"
 	microerror "github.com/giantswarm/microkit/error"
@@ -10,8 +12,22 @@ import (
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/runtime"
+	"k8s.io/client-go/pkg/watch"
+	"k8s.io/client-go/tools/cache"
 
+	k8sutil "github.com/giantswarm/cert-operator/client/k8s"
 	"github.com/giantswarm/cert-operator/flag"
+)
+
+const (
+	CertificateListAPIEndpoint  string = "/apis/giantswarm.io/v1/certificates"
+	CertificateWatchAPIEndpoint string = "/apis/giantswarm.io/v1/watch/certificates"
+
+	// Period for re-synchronizing the list of objects in k8s watcher. 0 means that re-sync will be
+	// delayed as long as possible, until the watch will be closed or timed out.
+	resyncPeriod time.Duration = 0
 )
 
 // Config represents the configuration used to create a create service.
@@ -80,7 +96,7 @@ type Service struct {
 	bootOnce sync.Once
 }
 
-// Boot starts the service
+// Boot starts the service and implements the watch for the certificate TPR.
 func (s *Service) Boot() {
 	s.bootOnce.Do(func() {
 		if err := s.createTPR(); err != nil {
@@ -88,19 +104,29 @@ func (s *Service) Boot() {
 		}
 		s.Config.Logger.Log("info", "successfully created third-party resource")
 
-		cert := certificatetpr.Spec{
-			ClusterID:  "cert-test",
-			CommonName: "api.cert-test.g8s.eu-west-1.aws.test.private.giantswarm.io",
-			IPSANs:     []string{"10.0.0.4", "10.0.0.5"},
-			AltNames: []string{
-				"kubernetes",
-				"kubernetes.default",
-				"kubernetes.default.svc",
-				"kubernetes.default.svc.cluster.local",
+		_, certInformer := cache.NewInformer(
+			s.newCertificateListWatch(),
+			&certificatetpr.CustomObject{},
+			resyncPeriod,
+			cache.ResourceEventHandlerFuncs{
+				AddFunc:    s.handleCertAdd,
+				DeleteFunc: s.handleCertDelete,
+				UpdateFunc: s.handleCertUpdate,
 			},
-			AllowBareDomains: true,
-			TTL:              "720h",
-		}
+		)
+
+		s.Config.Logger.Log("info", "starting watch")
+
+		// Certificate informer lifecycle can be interrupted by putting a value into a "stop channel".
+		// We aren't currently using that functionality, so we are passing a nil here.
+		certInformer.Run(nil)
+	})
+}
+
+// handleCertAdd issues a certificate using Vault for the certificate TPR. A PKI backend is
+// setup for the Cluster ID if it does not yet exist.
+func (s *Service) handleCertAdd(obj interface{}) {
+	cert := obj.(*certificatetpr.CustomObject)
 	s.Config.Logger.Log("info", fmt.Sprintf("creating certificate '%s'", cert.Spec.CommonName))
 
 	if err := s.setupPKIBackend(cert.Spec); err != nil {
@@ -118,7 +144,53 @@ func (s *Service) Boot() {
 		return
 	}
 	s.Config.Logger.Log("info", fmt.Sprintf("certificate issued %s", cert.Spec.CommonName))
+}
 
+// handleCertDelete is not yet implemented.
+func (s *Service) handleCertDelete(obj interface{}) {
+	cert := obj.(*certificatetpr.CustomObject)
+	s.Config.Logger.Log("info", fmt.Sprintf("deleting certificate '%s' is not implemented yet", cert.Spec.CommonName))
+}
+
+// handleCertUpdate is not yet implemented.
+func (s *Service) handleCertUpdate(old, cur interface{}) {
+	cert := cur.(*certificatetpr.CustomObject)
+	s.Config.Logger.Log("info", fmt.Sprintf("updating certificate '%s' is not implemented yet", cert.Spec.CommonName))
+}
+
+// newCertificateListWatch returns a configured list watch for the certificate TPR.
+func (s *Service) newCertificateListWatch() *cache.ListWatch {
+	client := s.Config.K8sClient.Core().RESTClient()
+
+	listWatch := &cache.ListWatch{
+		ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+			req := client.Get().AbsPath(CertificateListAPIEndpoint)
+			b, err := req.DoRaw()
+			if err != nil {
+				return nil, err
 			}
 
+			var c certificatetpr.List
+			if err := json.Unmarshal(b, &c); err != nil {
+				return nil, err
+			}
+
+			return &c, nil
+		},
+
+		WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+			req := client.Get().AbsPath(CertificateWatchAPIEndpoint)
+			stream, err := req.Stream()
+			if err != nil {
+				return nil, err
+			}
+
+			watcher := watch.NewStreamWatcher(&k8sutil.CertificateDecoder{
+				Stream: stream,
+			})
+
+			return watcher, nil
+		},
+	}
+	return listWatch
 }

--- a/service/create/third_party_resource.go
+++ b/service/create/third_party_resource.go
@@ -1,0 +1,27 @@
+package create
+
+import (
+	"github.com/giantswarm/certificatetpr"
+	microerror "github.com/giantswarm/microkit/error"
+	"k8s.io/client-go/pkg/api/errors"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+func (s *Service) createTPR() error {
+	tpr := &v1beta1.ThirdPartyResource{
+		ObjectMeta: v1.ObjectMeta{
+			Name: certificatetpr.Name,
+		},
+		Versions: []v1beta1.APIVersion{
+			{Name: "v1"},
+		},
+		Description: "Managed certificates on Kubernetes clusters",
+	}
+	_, err := s.Config.K8sClient.Extensions().ThirdPartyResources().Create(tpr)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}

--- a/service/create/third_party_resource.go
+++ b/service/create/third_party_resource.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
+// createTPR ensures certificatetpr exists on the cluster.
 func (s *Service) createTPR() error {
 	tpr := &v1beta1.ThirdPartyResource{
 		ObjectMeta: v1.ObjectMeta{
@@ -19,7 +20,9 @@ func (s *Service) createTPR() error {
 		Description: "Managed certificates on Kubernetes clusters",
 	}
 	_, err := s.Config.K8sClient.Extensions().ThirdPartyResources().Create(tpr)
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if errors.IsAlreadyExists(err) {
+		return nil
+	} else if err != nil {
 		return microerror.MaskAny(err)
 	}
 

--- a/vendor/github.com/giantswarm/certificatetpr/.gitignore
+++ b/vendor/github.com/giantswarm/certificatetpr/.gitignore
@@ -1,0 +1,3 @@
+certificatetpr
+TODO
+!vendor/**

--- a/vendor/github.com/giantswarm/certificatetpr/LICENSE
+++ b/vendor/github.com/giantswarm/certificatetpr/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 Giant Swarm GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/giantswarm/certificatetpr/README.md
+++ b/vendor/github.com/giantswarm/certificatetpr/README.md
@@ -1,0 +1,8 @@
+# certificatetpr
+
+Specification of the third party object used to issue certificates for Kubernetes clusters running
+on the Giantnetes platform from Giant Swarm. Used by the [cert-operator](https://github.com/giantswarm/cert-operator).
+
+## License
+
+certificatetpr is under the Apache 2.0 license. See the [LICENSE](LICENSE) file for details.

--- a/vendor/github.com/giantswarm/certificatetpr/custom_object.go
+++ b/vendor/github.com/giantswarm/certificatetpr/custom_object.go
@@ -1,0 +1,15 @@
+package certificatetpr
+
+import (
+	"k8s.io/client-go/pkg/api/unversioned"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+// CustomObject represents the Certificate TPR's custom object. It holds the
+// specifications of the resource the Certificate operator is interested in.
+type CustomObject struct {
+	unversioned.TypeMeta `json:",inline"`
+	v1.ObjectMeta        `json:"metadata,omitempty"`
+
+	Spec Spec `json:"spec" yaml:"spec"`
+}

--- a/vendor/github.com/giantswarm/certificatetpr/glide.lock
+++ b/vendor/github.com/giantswarm/certificatetpr/glide.lock
@@ -1,0 +1,127 @@
+hash: 4809645913ce6e57a8db18216d2fde7cef0d24f36c90de6ce4e988966914a3ce
+updated: 2017-03-23T12:11:15.997702172+01:00
+imports:
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew
+- name: github.com/docker/distribution
+  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
+  subpackages:
+  - digest
+  - reference
+- name: github.com/emicklei/go-restful
+  version: 89ef8af493ab468a45a42bb0d89a06fccdd2fb22
+  subpackages:
+  - log
+  - swagger
+- name: github.com/ghodss/yaml
+  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+- name: github.com/go-openapi/jsonpointer
+  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
+- name: github.com/go-openapi/jsonreference
+  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
+- name: github.com/go-openapi/spec
+  version: 6aced65f8501fe1217321abf0749d354824ba2ff
+- name: github.com/go-openapi/swag
+  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
+- name: github.com/gogo/protobuf
+  version: e18d7aa8f8c624c915db340349aad4c49b10d173
+  subpackages:
+  - proto
+  - sortkeys
+- name: github.com/golang/glog
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
+- name: github.com/google/gofuzz
+  version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
+- name: github.com/mailru/easyjson
+  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
+  subpackages:
+  - buffer
+  - jlexer
+  - jwriter
+- name: github.com/pborman/uuid
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
+- name: github.com/PuerkitoBio/purell
+  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
+- name: github.com/PuerkitoBio/urlesc
+  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/spf13/pflag
+  version: 5ccb023bc27df288a957c5e994cd44fd19619465
+- name: github.com/ugorji/go
+  version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
+  subpackages:
+  - codec
+- name: golang.org/x/net
+  version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
+  subpackages:
+  - context
+  - context/ctxhttp
+  - http2
+  - http2/hpack
+  - idna
+  - lex/httplex
+- name: golang.org/x/text
+  version: 2910a502d2bf9e43193af9d68ca516529614eed3
+  subpackages:
+  - cases
+  - internal/tag
+  - language
+  - runes
+  - secure/bidirule
+  - secure/precis
+  - transform
+  - unicode/bidi
+  - unicode/norm
+  - width
+- name: gopkg.in/inf.v0
+  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
+- name: gopkg.in/yaml.v2
+  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+- name: k8s.io/client-go
+  version: e121606b0d09b2e1c467183ee46217fa85a6b672
+  subpackages:
+  - pkg/api
+  - pkg/api/meta
+  - pkg/api/meta/metatypes
+  - pkg/api/resource
+  - pkg/api/unversioned
+  - pkg/api/v1
+  - pkg/apis/autoscaling
+  - pkg/apis/batch
+  - pkg/apis/extensions
+  - pkg/auth/user
+  - pkg/conversion
+  - pkg/conversion/queryparams
+  - pkg/fields
+  - pkg/genericapiserver/openapi/common
+  - pkg/labels
+  - pkg/runtime
+  - pkg/runtime/serializer
+  - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
+  - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/streaming
+  - pkg/runtime/serializer/versioning
+  - pkg/selection
+  - pkg/third_party/forked/golang/reflect
+  - pkg/types
+  - pkg/util
+  - pkg/util/errors
+  - pkg/util/framer
+  - pkg/util/intstr
+  - pkg/util/json
+  - pkg/util/labels
+  - pkg/util/net
+  - pkg/util/parsers
+  - pkg/util/rand
+  - pkg/util/runtime
+  - pkg/util/sets
+  - pkg/util/uuid
+  - pkg/util/validation
+  - pkg/util/validation/field
+  - pkg/util/wait
+  - pkg/util/yaml
+  - pkg/watch
+  - pkg/watch/versioned
+testImports: []

--- a/vendor/github.com/giantswarm/certificatetpr/glide.yaml
+++ b/vendor/github.com/giantswarm/certificatetpr/glide.yaml
@@ -1,0 +1,7 @@
+package: github.com/giantswarm/certificatetpr
+import:
+- package: k8s.io/client-go
+  version: ^2.0.0
+  subpackages:
+  - pkg/api/unversioned
+  - pkg/api/v1

--- a/vendor/github.com/giantswarm/certificatetpr/list.go
+++ b/vendor/github.com/giantswarm/certificatetpr/list.go
@@ -1,0 +1,12 @@
+package certificatetpr
+
+import (
+	"k8s.io/client-go/pkg/api/unversioned"
+)
+
+type List struct {
+	unversioned.TypeMeta `json:",inline"`
+	unversioned.ListMeta `json:"metadata,omitempty"`
+
+	Items []*CustomObject `json:"items"`
+}

--- a/vendor/github.com/giantswarm/certificatetpr/name.go
+++ b/vendor/github.com/giantswarm/certificatetpr/name.go
@@ -1,0 +1,6 @@
+package certificatetpr
+
+const (
+	// Name represents the name of the third party resource within Kubernetes.
+	Name = "certificate.giantswarm.io"
+)

--- a/vendor/github.com/giantswarm/certificatetpr/spec.go
+++ b/vendor/github.com/giantswarm/certificatetpr/spec.go
@@ -1,0 +1,10 @@
+package certificatetpr
+
+type Spec struct {
+	AllowBareDomains bool     `json:"allowBareDomains" yaml:"allowBareDomains"`
+	AltNames         []string `json:"altNames" yaml:"altNames"`
+	ClusterID        string   `json:"clusterID" yaml:"clusterID"`
+	CommonName       string   `json:"commonName" yaml:"commonName"`
+	IPSANs           []string `json:"ipSans" yaml:"ipSans"`
+	TTL              string   `json:"ttl" yaml:"ttl"`
+}


### PR DESCRIPTION
Towards giantswarm/giantswarm#1255 and #13 

This PR integrates the certificatetpr, creates the TPR on boot and watches for cert TPOs. The AddFunc is implemented and will issue a cert. The error handling for issuing certs has been cleaned up as requested in #13

Still to be implemented

- DeleteFunc
- UpdateFunc
- Saving certs as k8s secrets
- Retry logic on failure

I'd like to do these as follow on PRs.

~~I'm also still tracking down a bug with bare domains not being accepted as alternate names for the certs.~~
