### PR TITLE
Save certificates as k8s secrets and implement delete watch

### DIFF
--- a/examples/example-cert.yaml
+++ b/examples/example-cert.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "example-cert"
 spec:
   clusterID: "cert-test"
+  clusterComponent: "kubernetes"
   commonName: "api.cert-test.g8s.eu-west-1.aws.test.private.giantswarm.io"
   altNames:
   - "cert-test.g8s.eu-west-1.aws.test.private.giantswarm.io"

--- a/glide.lock
+++ b/glide.lock
@@ -66,7 +66,7 @@ imports:
   - service/spec
   - service/token
 - name: github.com/giantswarm/certificatetpr
-  version: 42a7d2d2af0b2f8bb375a46134111211f0345ba7
+  version: e7556ebe23341e8de38174e2a8ad85332281a670
 - name: github.com/giantswarm/go-uuid
   version: ed3ca8a15a931b141440a7e98e4f716eec255f7d
   subpackages:

--- a/service/create/cert_signer.go
+++ b/service/create/cert_signer.go
@@ -10,32 +10,39 @@ import (
 )
 
 // Issue generates a certificate using the PKI backend signed by the certificate
-// authority associated with the configured cluster ID.
-func (s *Service) Issue(cert certificatetpr.Spec) (spec.IssueResponse, error) {
-	var issueResp spec.IssueResponse
-
-	// Create a certificate signer to generate a new signed certificate.
+// authority associated with the configured cluster ID. The certificate is saved
+// as a set of k8s secrets.
+func (s *Service) Issue(cert *certificatetpr.CustomObject) error {
 	newCertSignerConfig := certsigner.DefaultConfig()
 	newCertSignerConfig.VaultClient = s.Config.VaultClient
 
 	newCertSigner, err := certsigner.New(newCertSignerConfig)
 	if err != nil {
-		return issueResp, microerror.MaskAny(err)
+		return microerror.MaskAny(err)
 	}
 
 	// Generate a new signed certificate.
 	newIssueConfig := spec.IssueConfig{
-		ClusterID:  cert.ClusterID,
-		CommonName: cert.CommonName,
-		IPSANs:     strings.Join(cert.IPSANs, ","),
-		AltNames:   strings.Join(cert.AltNames, ","),
-		TTL:        cert.TTL,
+		ClusterID:  cert.Spec.ClusterID,
+		CommonName: cert.Spec.CommonName,
+		IPSANs:     strings.Join(cert.Spec.IPSANs, ","),
+		AltNames:   strings.Join(cert.Spec.AltNames, ","),
+		TTL:        cert.Spec.TTL,
 	}
-
 	newIssueResponse, err := newCertSigner.Issue(newIssueConfig)
 	if err != nil {
-		return issueResp, microerror.MaskAny(err)
+		return microerror.MaskAny(err)
 	}
 
-	return newIssueResponse, err
+	// Save the certificate as a k8s secret.
+	secret := certificateSecret{
+		CommonName:    cert.Spec.CommonName,
+		Namespace:     cert.ObjectMeta.Namespace,
+		IssueResponse: newIssueResponse,
+	}
+	if err := s.SaveCertificate(secret); err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
 }

--- a/service/create/cert_signer.go
+++ b/service/create/cert_signer.go
@@ -36,9 +36,10 @@ func (s *Service) Issue(cert *certificatetpr.CustomObject) error {
 
 	// Save the certificate as a k8s secret.
 	secret := certificateSecret{
-		CommonName:    cert.Spec.CommonName,
-		Namespace:     cert.ObjectMeta.Namespace,
-		IssueResponse: newIssueResponse,
+		ClusterComponent: cert.Spec.ClusterComponent,
+		CommonName:       cert.Spec.CommonName,
+		Namespace:        cert.ObjectMeta.Namespace,
+		IssueResponse:    newIssueResponse,
 	}
 	if err := s.CreateCertificate(secret); err != nil {
 		return microerror.MaskAny(err)

--- a/service/create/cert_signer.go
+++ b/service/create/cert_signer.go
@@ -40,7 +40,7 @@ func (s *Service) Issue(cert *certificatetpr.CustomObject) error {
 		Namespace:     cert.ObjectMeta.Namespace,
 		IssueResponse: newIssueResponse,
 	}
-	if err := s.SaveCertificate(secret); err != nil {
+	if err := s.CreateCertificate(secret); err != nil {
 		return microerror.MaskAny(err)
 	}
 

--- a/service/create/k8s_secret.go
+++ b/service/create/k8s_secret.go
@@ -39,3 +39,16 @@ func (s *Service) SaveCertificate(cert certificateSecret) error {
 
 	return nil
 }
+
+// DeleteCertificate deletes the k8s secret that stores the certificate.
+func (s *Service) DeleteCertificate(cert *certificatetpr.CustomObject) error {
+	namespace := cert.ObjectMeta.Namespace
+	secretName := cert.Spec.CommonName
+
+	err := s.Config.K8sClient.Core().Secrets(namespace).Delete(secretName, &v1.DeleteOptions{})
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}

--- a/service/create/k8s_secret.go
+++ b/service/create/k8s_secret.go
@@ -14,6 +14,9 @@ func (s *Service) CreateCertificate(cert certificateSecret) error {
 	secret := &v1.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name: cert.CommonName,
+			Labels: map[string]string{
+				"clusterComponent": cert.ClusterComponent,
+			},
 		},
 		StringData: map[string]string{
 			"crt": cert.IssueResponse.Certificate,

--- a/service/create/k8s_secret.go
+++ b/service/create/k8s_secret.go
@@ -1,0 +1,41 @@
+package create
+
+import (
+	"github.com/giantswarm/certificatetpr"
+	microerror "github.com/giantswarm/microkit/error"
+	"k8s.io/client-go/pkg/api/errors"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+// SaveCertificate saves the certificate as a k8s secret.
+func (s *Service) SaveCertificate(cert certificateSecret) error {
+	var err error
+
+	secret := &v1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name: cert.CommonName,
+		},
+		StringData: map[string]string{
+			"crt": cert.IssueResponse.Certificate,
+			"key": cert.IssueResponse.PrivateKey,
+			"ca":  cert.IssueResponse.IssuingCA,
+		},
+	}
+
+	// Create the secret.
+	_, err = s.Config.K8sClient.Core().Secrets(cert.Namespace).Create(secret)
+	if errors.IsAlreadyExists(err) {
+		// Update the secret if it already exists.
+		_, err = s.Config.K8sClient.Core().Secrets(cert.Namespace).Update(secret)
+		if err != nil {
+			return microerror.MaskAny(err)
+		}
+
+		return nil
+
+	} else if err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -153,10 +153,17 @@ func (s *Service) addFunc(obj interface{}) {
 	s.Config.Logger.Log("info", fmt.Sprintf("certificate '%s' issued", cert.Spec.CommonName))
 }
 
-// deleteFunc is not yet implemented.
+// deleteFunc deletes the k8s secret containing the certificate.
 func (s *Service) deleteFunc(obj interface{}) {
 	cert := obj.(*certificatetpr.CustomObject)
-	s.Config.Logger.Log("info", fmt.Sprintf("deleting certificate '%s' is not implemented yet", cert.Spec.CommonName))
+	s.Config.Logger.Log("debug", fmt.Sprintf("deleting certificate '%s'", cert.Spec.CommonName))
+
+	if err := s.DeleteCertificate(cert); err != nil {
+		s.Config.Logger.Log("error", fmt.Sprintf("could not delete certificate '%#v'", err))
+		return
+	}
+
+	s.Config.Logger.Log("info", fmt.Sprintf("certificate '%s' deleted", cert.Spec.CommonName))
 }
 
 // updateFunc is not yet implemented.

--- a/service/create/service.go
+++ b/service/create/service.go
@@ -45,9 +45,10 @@ type Config struct {
 
 // certificateSecret stores a cert issued by Vault that will be stored as a k8s secret.
 type certificateSecret struct {
-	CommonName    string
-	Namespace     string
-	IssueResponse spec.IssueResponse
+	ClusterComponent string
+	CommonName       string
+	Namespace        string
+	IssueResponse    spec.IssueResponse
 }
 
 // DefaultConfig provides a default configuration to create a new create service

--- a/vendor/github.com/giantswarm/certificatetpr/spec.go
+++ b/vendor/github.com/giantswarm/certificatetpr/spec.go
@@ -3,6 +3,7 @@ package certificatetpr
 type Spec struct {
 	AllowBareDomains bool     `json:"allowBareDomains" yaml:"allowBareDomains"`
 	AltNames         []string `json:"altNames" yaml:"altNames"`
+	ClusterComponent string   `json:"clusterComponent" yaml:"clusterComponent"`
 	ClusterID        string   `json:"clusterID" yaml:"clusterID"`
 	CommonName       string   `json:"commonName" yaml:"commonName"`
 	IPSANs           []string `json:"ipSans" yaml:"ipSans"`


### PR DESCRIPTION
Towards giantswarm/giantswarm#1255

This PR implements saving the certs issued by Vault as a k8s secret. It also implements the delete watch which deletes the secret when the TPO is deleted.

Not yet implemented is updateFunc as well as retry logic for Vault and K8s API calls. These will be done as follow up PRs.