### PR TITLE
Split Create service into Ca and Crt services

### DIFF
--- a/service/ca/error.go
+++ b/service/ca/error.go
@@ -1,0 +1,12 @@
+package ca
+
+import (
+	"github.com/juju/errgo"
+)
+
+var invalidConfigError = errgo.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return errgo.Cause(err) == invalidConfigError
+}

--- a/service/ca/pki.go
+++ b/service/ca/pki.go
@@ -1,4 +1,4 @@
-package create
+package ca
 
 import (
 	"fmt"
@@ -9,6 +9,23 @@ import (
 	"github.com/giantswarm/certificatetpr"
 	microerror "github.com/giantswarm/microkit/error"
 )
+
+// SetupPKI creates a PKI backend and policy if one does not exists for the cluster.
+func (s *Service) SetupPKI(cert *certificatetpr.CustomObject) error {
+	s.Config.Logger.Log("debug", fmt.Sprintf("setting up PKI for cluster '%s'", cert.Spec.ClusterID))
+
+	if err := s.setupPKIBackend(cert.Spec); err != nil {
+		s.Config.Logger.Log("error", fmt.Sprintf("could not setup pki backend '%#v'", err))
+		return err
+	}
+	if err := s.setupPKIPolicy(cert.Spec); err != nil {
+		s.Config.Logger.Log("error", fmt.Sprintf("could not setup pki policy '%#v'", err))
+		return err
+	}
+
+	s.Config.Logger.Log("debug", fmt.Sprintf("valid PKI exists for cluster '%s'", cert.Spec.ClusterID))
+	return nil
+}
 
 // setupPKIBackend creates a PKI backend if one does not exist for the cluster.
 func (s *Service) setupPKIBackend(cert certificatetpr.Spec) error {

--- a/service/ca/pki_test.go
+++ b/service/ca/pki_test.go
@@ -1,4 +1,4 @@
-package create
+package ca
 
 import (
 	"fmt"

--- a/service/ca/service.go
+++ b/service/ca/service.go
@@ -1,0 +1,73 @@
+package ca
+
+import (
+	"sync"
+
+	microerror "github.com/giantswarm/microkit/error"
+	micrologger "github.com/giantswarm/microkit/logger"
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/spf13/viper"
+
+	"github.com/giantswarm/cert-operator/flag"
+)
+
+// Config represents the configuration used to create a CA service.
+type Config struct {
+	// Dependencies.
+	Logger      micrologger.Logger
+	VaultClient *vaultapi.Client
+
+	// Settings.
+	Flag  *flag.Flag
+	Viper *viper.Viper
+}
+
+// DefaultConfig provides a default configuration to create a new CA service
+// by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger:      nil,
+		VaultClient: nil,
+
+		// Settings.
+		Flag:  nil,
+		Viper: nil,
+	}
+}
+
+// New creates a new configured CA service.
+func New(config Config) (*Service, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.MaskAnyf(invalidConfigError, "logger must not be empty")
+	}
+	if config.VaultClient == nil {
+		return nil, microerror.MaskAnyf(invalidConfigError, "vault client must not be empty")
+	}
+
+	// Settings.
+	if config.Flag == nil {
+		return nil, microerror.MaskAnyf(invalidConfigError, "flag must not be empty")
+	}
+	if config.Viper == nil {
+		return nil, microerror.MaskAnyf(invalidConfigError, "viper must not be empty")
+	}
+
+	newService := &Service{
+		Config: config,
+
+		// Internals
+		bootOnce: sync.Once{},
+	}
+
+	return newService, nil
+}
+
+// Service implements the CA service interface.
+type Service struct {
+	Config
+
+	// Internals.
+	bootOnce sync.Once
+}

--- a/service/crt/cert_signer.go
+++ b/service/crt/cert_signer.go
@@ -1,4 +1,4 @@
-package create
+package crt
 
 import (
 	"strings"

--- a/service/crt/error.go
+++ b/service/crt/error.go
@@ -1,4 +1,4 @@
-package create
+package crt
 
 import (
 	"github.com/juju/errgo"

--- a/service/crt/k8s_secret.go
+++ b/service/crt/k8s_secret.go
@@ -1,4 +1,4 @@
-package create
+package crt
 
 import (
 	"github.com/giantswarm/certificatetpr"

--- a/service/crt/third_party_resource.go
+++ b/service/crt/third_party_resource.go
@@ -1,4 +1,4 @@
-package create
+package crt
 
 import (
 	"github.com/giantswarm/certificatetpr"


### PR DESCRIPTION
Toward giantswarm/giantswarm#1255 and implements #11 

This PR splits the Create service into Ca and Crt services. This is to prepare for moving the CA setup logic to a separate ca-operator with it's own TPR. Also fixes some incorrect comments.
