### PR TITLE
Add example certs for all cluster components.

### DIFF
--- a/examples/api-cert.yaml
+++ b/examples/api-cert.yaml
@@ -1,11 +1,11 @@
 apiVersion: "giantswarm.io/v1"
 kind: Certificate
 metadata:
-  name: "uo91f-apiserver"
+  name: "uo91f-api"
   namespace: "default"
 spec:
   clusterID: "uo91f"
-  clusterComponent: "apiserver"
+  clusterComponent: "api"
   commonName: "api.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
   altNames:
   - "uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"

--- a/examples/apiserver-cert.yaml
+++ b/examples/apiserver-cert.yaml
@@ -1,20 +1,20 @@
 apiVersion: "giantswarm.io/v1"
 kind: Certificate
 metadata:
-  name: "example-cert"
+  name: "uo91f-apiserver"
+  namespace: "uo91f"
 spec:
-  clusterID: "cert-test"
-  clusterComponent: "kubernetes"
-  commonName: "api.cert-test.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  clusterID: "uo91f"
+  clusterComponent: "apiserver"
+  commonName: "api.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
   altNames:
-  - "cert-test.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  - "uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
   - "k8s-master-vm"
   - "kubernetes"
   - "kubernetes.default"
   - "kubernetes.default.svc"
   - "kubernetes.default.svc.cluster.local"
   ipSans:
-  - "10.0.2.1"
   - "10.0.2.2"
   ttl: "720h"
   allowBareDomains: true

--- a/examples/apiserver-cert.yaml
+++ b/examples/apiserver-cert.yaml
@@ -2,7 +2,7 @@ apiVersion: "giantswarm.io/v1"
 kind: Certificate
 metadata:
   name: "uo91f-apiserver"
-  namespace: "uo91f"
+  namespace: "default"
 spec:
   clusterID: "uo91f"
   clusterComponent: "apiserver"

--- a/examples/calico-cert.yaml
+++ b/examples/calico-cert.yaml
@@ -1,0 +1,14 @@
+apiVersion: "giantswarm.io/v1"
+kind: Certificate
+metadata:
+  name: "uo91f-calico"
+  namespace: "uo91f"
+spec:
+  clusterID: "uo91f"
+  clusterComponent: "calico"
+  commonName: "calico.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  altNames:
+  ipSans:
+  - "10.0.2.2"
+  ttl: "720h"
+  allowBareDomains: false

--- a/examples/calico-cert.yaml
+++ b/examples/calico-cert.yaml
@@ -2,7 +2,7 @@ apiVersion: "giantswarm.io/v1"
 kind: Certificate
 metadata:
   name: "uo91f-calico"
-  namespace: "uo91f"
+  namespace: "default"
 spec:
   clusterID: "uo91f"
   clusterComponent: "calico"

--- a/examples/etcd-cert.yaml
+++ b/examples/etcd-cert.yaml
@@ -2,7 +2,7 @@ apiVersion: "giantswarm.io/v1"
 kind: Certificate
 metadata:
   name: "uo91f-etcd"
-  namespace: "uo91f"
+  namespace: "default"
 spec:
   clusterID: "uo91f"
   clusterComponent: "etcd"

--- a/examples/etcd-cert.yaml
+++ b/examples/etcd-cert.yaml
@@ -1,0 +1,14 @@
+apiVersion: "giantswarm.io/v1"
+kind: Certificate
+metadata:
+  name: "uo91f-etcd"
+  namespace: "uo91f"
+spec:
+  clusterID: "uo91f"
+  clusterComponent: "etcd"
+  commonName: "etcd.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  altNames:
+  ipSans:
+  - "10.0.2.2"
+  ttl: "720h"
+  allowBareDomains: false

--- a/examples/worker-cert.yaml
+++ b/examples/worker-cert.yaml
@@ -1,0 +1,20 @@
+apiVersion: "giantswarm.io/v1"
+kind: Certificate
+metadata:
+  name: "uo91f-worker"
+  namespace: "uo91f"
+spec:
+  clusterID: "uo91f"
+  clusterComponent: "worker"
+  commonName: "api.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  altNames:
+  - "uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  - "k8s-master-vm"
+  - "kubernetes"
+  - "kubernetes.default"
+  - "kubernetes.default.svc"
+  - "kubernetes.default.svc.cluster.local"
+  ipSans:
+  - "10.0.2.2"
+  ttl: "720h"
+  allowBareDomains: true

--- a/examples/worker-cert.yaml
+++ b/examples/worker-cert.yaml
@@ -2,7 +2,7 @@ apiVersion: "giantswarm.io/v1"
 kind: Certificate
 metadata:
   name: "uo91f-worker"
-  namespace: "uo91f"
+  namespace: "default"
 spec:
   clusterID: "uo91f"
   clusterComponent: "worker"

--- a/examples/worker-cert.yaml
+++ b/examples/worker-cert.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   clusterID: "uo91f"
   clusterComponent: "worker"
-  commonName: "api.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  commonName: "worker.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
   altNames:
   ipSans:
   - "10.0.2.2"

--- a/examples/worker-cert.yaml
+++ b/examples/worker-cert.yaml
@@ -8,13 +8,7 @@ spec:
   clusterComponent: "worker"
   commonName: "api.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
   altNames:
-  - "uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
-  - "k8s-master-vm"
-  - "kubernetes"
-  - "kubernetes.default"
-  - "kubernetes.default.svc"
-  - "kubernetes.default.svc.cluster.local"
   ipSans:
   - "10.0.2.2"
   ttl: "720h"
-  allowBareDomains: true
+  allowBareDomains: false


### PR DESCRIPTION
Towards giantswarm/giantswarm#1255 

This PR adds example certs for each cluster component. The actual certificate TPOs will be created by kubernetesd using data from the cluster TPO but there are some gaps currently.

- apiserver
- worker
- etcd
- calico

I'd like to get these TPOs as close to the actual ones as possible. I'll then automate in kubernetesd. For now I've agreed with @asymmetric that we'll use the default namespace. This is while we decide if the TPOs should live in the cluster namespace.
