### PR TITLE
Removes extraneous golang version from build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ dependencies:
 
 test:
   override:
-    - ./architect build --golang-version=1.8.0
+    - ./architect build
 
 deployment:
   master:


### PR DESCRIPTION
`1.8.0` is the default version now