### PR TITLE
Updated tpos to match awstpr example

### DIFF
--- a/examples/api-cert.yaml
+++ b/examples/api-cert.yaml
@@ -1,14 +1,14 @@
 apiVersion: "giantswarm.io/v1"
 kind: Certificate
 metadata:
-  name: "uo91f-api"
+  name: "example-cluster-api"
   namespace: "default"
 spec:
-  clusterID: "uo91f"
+  clusterID: "example-cluster"
   clusterComponent: "api"
-  commonName: "api.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  commonName: "api.example-cluster.g8s.eu-west-1.aws.private.giantswarm.io"
   altNames:
-  - "uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  - "example-cluster.g8s.eu-west-1.aws.private.giantswarm.io"
   - "k8s-master-vm"
   - "kubernetes"
   - "kubernetes.default"

--- a/examples/calico-cert.yaml
+++ b/examples/calico-cert.yaml
@@ -1,12 +1,12 @@
 apiVersion: "giantswarm.io/v1"
 kind: Certificate
 metadata:
-  name: "uo91f-calico"
+  name: "example-cluster-calico"
   namespace: "default"
 spec:
-  clusterID: "uo91f"
+  clusterID: "example-cluster"
   clusterComponent: "calico"
-  commonName: "calico.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  commonName: "calico.example-cluster.g8s.eu-west-1.aws.private.giantswarm.io"
   altNames:
   ipSans:
   - "10.0.2.2"

--- a/examples/etcd-cert.yaml
+++ b/examples/etcd-cert.yaml
@@ -1,12 +1,12 @@
 apiVersion: "giantswarm.io/v1"
 kind: Certificate
 metadata:
-  name: "uo91f-etcd"
+  name: "example-cluster-etcd"
   namespace: "default"
 spec:
-  clusterID: "uo91f"
+  clusterID: "example-cluster"
   clusterComponent: "etcd"
-  commonName: "etcd.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  commonName: "etcd.example-cluster.g8s.eu-west-1.aws.private.giantswarm.io"
   altNames:
   ipSans:
   - "10.0.2.2"

--- a/examples/worker-cert.yaml
+++ b/examples/worker-cert.yaml
@@ -1,12 +1,12 @@
 apiVersion: "giantswarm.io/v1"
 kind: Certificate
 metadata:
-  name: "uo91f-worker"
+  name: "example-cluster-worker"
   namespace: "default"
 spec:
-  clusterID: "uo91f"
+  clusterID: "example-cluster"
   clusterComponent: "worker"
-  commonName: "worker.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  commonName: "worker.example-cluster.g8s.eu-west-1.aws.private.giantswarm.io"
   altNames:
   ipSans:
   - "10.0.2.2"


### PR DESCRIPTION
Updated TPOs for testing to match awstpr example.

Can we confirm that api.example-cluster.g8s.eu-west-1.aws.private.giantswarm.io is the correct format for the CN?