### PR TITLE
Better type handling

### DIFF
--- a/service/ca/pki.go
+++ b/service/ca/pki.go
@@ -11,19 +11,19 @@ import (
 )
 
 // SetupPKI creates a PKI backend and policy if one does not exists for the cluster.
-func (s *Service) SetupPKI(cert *certificatetpr.CustomObject) error {
-	s.Config.Logger.Log("debug", fmt.Sprintf("setting up PKI for cluster '%s'", cert.Spec.ClusterID))
+func (s *Service) SetupPKI(cert certificatetpr.Spec) error {
+	s.Config.Logger.Log("debug", fmt.Sprintf("setting up PKI for cluster '%s'", cert.ClusterID))
 
-	if err := s.setupPKIBackend(cert.Spec); err != nil {
+	if err := s.setupPKIBackend(cert); err != nil {
 		s.Config.Logger.Log("error", fmt.Sprintf("could not setup pki backend '%#v'", err))
 		return err
 	}
-	if err := s.setupPKIPolicy(cert.Spec); err != nil {
+	if err := s.setupPKIPolicy(cert); err != nil {
 		s.Config.Logger.Log("error", fmt.Sprintf("could not setup pki policy '%#v'", err))
 		return err
 	}
 
-	s.Config.Logger.Log("debug", fmt.Sprintf("valid PKI exists for cluster '%s'", cert.Spec.ClusterID))
+	s.Config.Logger.Log("debug", fmt.Sprintf("valid PKI exists for cluster '%s'", cert.ClusterID))
 	return nil
 }
 

--- a/service/crt/cert_signer.go
+++ b/service/crt/cert_signer.go
@@ -12,7 +12,7 @@ import (
 // Issue generates a certificate using the PKI backend signed by the certificate
 // authority associated with the configured cluster ID. The certificate is saved
 // as a set of k8s secrets.
-func (s *Service) Issue(cert *certificatetpr.CustomObject) error {
+func (s *Service) Issue(cert certificatetpr.Spec) error {
 	newCertSignerConfig := certsigner.DefaultConfig()
 	newCertSignerConfig.VaultClient = s.Config.VaultClient
 
@@ -23,11 +23,11 @@ func (s *Service) Issue(cert *certificatetpr.CustomObject) error {
 
 	// Generate a new signed certificate.
 	newIssueConfig := spec.IssueConfig{
-		ClusterID:  cert.Spec.ClusterID,
-		CommonName: cert.Spec.CommonName,
-		IPSANs:     strings.Join(cert.Spec.IPSANs, ","),
-		AltNames:   strings.Join(cert.Spec.AltNames, ","),
-		TTL:        cert.Spec.TTL,
+		ClusterID:  cert.ClusterID,
+		CommonName: cert.CommonName,
+		IPSANs:     strings.Join(cert.IPSANs, ","),
+		AltNames:   strings.Join(cert.AltNames, ","),
+		TTL:        cert.TTL,
 	}
 	newIssueResponse, err := newCertSigner.Issue(newIssueConfig)
 	if err != nil {

--- a/service/crt/k8s_secret.go
+++ b/service/crt/k8s_secret.go
@@ -17,8 +17,8 @@ func (s *Service) CreateCertificate(secret certificateSecret) error {
 		ObjectMeta: v1.ObjectMeta{
 			Name: getSecretName(secret.Certificate),
 			Labels: map[string]string{
-				certificatetpr.ClusterIDLabel: secret.Certificate.Spec.ClusterID,
-				certificatetpr.ComponentLabel: secret.Certificate.Spec.ClusterComponent,
+				certificatetpr.ClusterIDLabel: secret.Certificate.ClusterID,
+				certificatetpr.ComponentLabel: secret.Certificate.ClusterComponent,
 			},
 		},
 		StringData: map[string]string{
@@ -40,7 +40,7 @@ func (s *Service) CreateCertificate(secret certificateSecret) error {
 }
 
 // DeleteCertificate deletes the k8s secret that stores the certificate.
-func (s *Service) DeleteCertificate(cert *certificatetpr.CustomObject) error {
+func (s *Service) DeleteCertificate(cert certificatetpr.Spec) error {
 	// Delete the secret which should be idempotent.
 	err := s.Config.K8sClient.Core().Secrets(v1.NamespaceDefault).Delete(getSecretName(cert), &v1.DeleteOptions{})
 	if errors.IsNotFound(err) {
@@ -52,6 +52,6 @@ func (s *Service) DeleteCertificate(cert *certificatetpr.CustomObject) error {
 	return nil
 }
 
-func getSecretName(cert *certificatetpr.CustomObject) string {
-	return fmt.Sprintf("%s-%s", cert.Spec.ClusterID, cert.Spec.ClusterComponent)
+func getSecretName(cert certificatetpr.Spec) string {
+	return fmt.Sprintf("%s-%s", cert.ClusterID, cert.ClusterComponent)
 }

--- a/service/crt/service.go
+++ b/service/crt/service.go
@@ -47,7 +47,7 @@ type Config struct {
 
 // certificateSecret stores a cert issued by Vault that will be stored as a k8s secret.
 type certificateSecret struct {
-	Certificate   *certificatetpr.CustomObject
+	Certificate   certificatetpr.Spec
 	IssueResponse spec.IssueResponse
 }
 
@@ -138,14 +138,14 @@ func (s *Service) Boot() {
 // addFunc issues a certificate using Vault for the certificate TPR. A PKI backend is
 // setup for the Cluster ID if it does not yet exist.
 func (s *Service) addFunc(obj interface{}) {
-	cert := obj.(*certificatetpr.CustomObject)
+	cert := *obj.(*certificatetpr.CustomObject)
 	s.Config.Logger.Log("debug", fmt.Sprintf("creating certificate '%s'", cert.Spec.CommonName))
 
-	if err := s.Config.CAService.SetupPKI(cert); err != nil {
+	if err := s.Config.CAService.SetupPKI(cert.Spec); err != nil {
 		s.Config.Logger.Log("error", fmt.Sprintf("could not setup PKI '%#v'", err))
 		return
 	}
-	if err := s.Issue(cert); err != nil {
+	if err := s.Issue(cert.Spec); err != nil {
 		s.Config.Logger.Log("error", fmt.Sprintf("could not issue cert '%#v'", err))
 		return
 	}
@@ -155,10 +155,10 @@ func (s *Service) addFunc(obj interface{}) {
 
 // deleteFunc deletes the k8s secret containing the certificate.
 func (s *Service) deleteFunc(obj interface{}) {
-	cert := obj.(*certificatetpr.CustomObject)
+	cert := *obj.(*certificatetpr.CustomObject)
 	s.Config.Logger.Log("debug", fmt.Sprintf("deleting certificate '%s'", cert.Spec.CommonName))
 
-	if err := s.DeleteCertificate(cert); err != nil {
+	if err := s.DeleteCertificate(cert.Spec); err != nil {
 		s.Config.Logger.Log("error", fmt.Sprintf("could not delete certificate '%#v'", err))
 		return
 	}


### PR DESCRIPTION
Towards giantswarm/giantswarm#1371

This PR improves the type handling and may help reduce the high memory usage on AWS.

- The watches now cast to a pointer to the custom object rather than the value.
- Everywhere else a certificatetpr.Spec value is passed and this simplifies the code in several places.