### PR TITLE
Use multiple args for config file flags

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -50,8 +50,10 @@ spec:
           containerPort: 8000
         args:
         - daemon
-        - --config.dirs="/var/run/cert-operator/configmap/ /var/run/cert-operator/secret/"
-        - --config.files="config secret"
+        - --config.dirs=/var/run/cert-operator/configmap/
+        - --config.dirs=/var/run/cert-operator/secret/
+        - --config.files=config
+        - --config.files=secret
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Towards giantswarm/giantswarm#1388

Fixes problem with operator failing to start because values can't be read from the config map. This is because the config args are being parsed as strings rather than string slices. Meaning that the secrets file is read but not the config map.

The fix is to specify the config files and dirs examples multiple times as shown in this pflag [issue](https://github.com/spf13/pflag/issues/40). The bug is strange because it occurs in k8s but not locally.