### PR TITLE
add service-account  and improve example TPOs

### DIFF
--- a/examples/api-cert.yaml
+++ b/examples/api-cert.yaml
@@ -1,20 +1,19 @@
 apiVersion: "giantswarm.io/v1"
 kind: Certificate
 metadata:
-  name: "uo91f-api"
+  name: "example-cluster-api"
   namespace: "default"
 spec:
-  clusterID: "uo91f"
+  clusterID: "example-cluster"
   clusterComponent: "api"
-  commonName: "api.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  commonName: "api.example-cluster.aws.giantswarm.io"
   altNames:
-  - "uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  - "example-cluster.aws.giantswarm.io"
   - "k8s-master-vm"
   - "kubernetes"
   - "kubernetes.default"
   - "kubernetes.default.svc"
   - "kubernetes.default.svc.cluster.local"
   ipSans:
-  - "10.0.2.2"
   ttl: "720h"
   allowBareDomains: true

--- a/examples/calico-cert.yaml
+++ b/examples/calico-cert.yaml
@@ -1,14 +1,13 @@
 apiVersion: "giantswarm.io/v1"
 kind: Certificate
 metadata:
-  name: "uo91f-calico"
+  name: "example-cluster-calico"
   namespace: "default"
 spec:
-  clusterID: "uo91f"
+  clusterID: "example-cluster"
   clusterComponent: "calico"
-  commonName: "calico.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  commonName: "calico.example-cluster.aws.giantswarm.io"
   altNames:
   ipSans:
-  - "10.0.2.2"
   ttl: "720h"
   allowBareDomains: false

--- a/examples/etcd-cert.yaml
+++ b/examples/etcd-cert.yaml
@@ -1,14 +1,13 @@
 apiVersion: "giantswarm.io/v1"
 kind: Certificate
 metadata:
-  name: "uo91f-etcd"
+  name: "example-cluster-etcd"
   namespace: "default"
 spec:
-  clusterID: "uo91f"
+  clusterID: "example-cluster"
   clusterComponent: "etcd"
-  commonName: "etcd.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  commonName: "etcd.example-cluster.aws.giantswarm.io"
   altNames:
   ipSans:
-  - "10.0.2.2"
   ttl: "720h"
   allowBareDomains: false

--- a/examples/service-account-cert.yaml
+++ b/examples/service-account-cert.yaml
@@ -1,0 +1,13 @@
+apiVersion: "giantswarm.io/v1"
+kind: Certificate
+metadata:
+  name: "example-cluster-service-account"
+  namespace: "default"
+spec:
+  clusterID: "example-cluster"
+  clusterComponent: "service-account"
+  commonName: "service-account.example-cluster.aws.giantswarm.io"
+  altNames:
+  ipSans:
+  ttl: "720h"
+  allowBareDomains: false

--- a/examples/worker-cert.yaml
+++ b/examples/worker-cert.yaml
@@ -1,14 +1,19 @@
 apiVersion: "giantswarm.io/v1"
 kind: Certificate
 metadata:
-  name: "uo91f-worker"
+  name: "example-cluster-worker"
   namespace: "default"
 spec:
-  clusterID: "uo91f"
+  clusterID: "example-cluster"
   clusterComponent: "worker"
-  commonName: "worker.uo91f.g8s.eu-west-1.aws.test.private.giantswarm.io"
+  commonName: "worker.example-cluster.aws.giantswarm.io"
   altNames:
+  - "example-cluster.aws.giantswarm.io"
+  - "k8s-master-vm"
+  - "kubernetes"
+  - "kubernetes.default"
+  - "kubernetes.default.svc"
+  - "kubernetes.default.svc.cluster.local"
   ipSans:
-  - "10.0.2.2"
   ttl: "720h"
   allowBareDomains: false


### PR DESCRIPTION
This PR adds a missing example cert for the service account. It also does some boyscouting to make it possible launch a "local" AWS cluster using them.

Changes are

- clusterID is `example-cluster` to match AWS example TPO.
- simpler domain format `api.example-cluster.aws.giantswarm.io`  but uses `aws.giantswarm.io` which is delegated to Route 53 from CloudFlare.