### PR TITLE
Docs for running cert-operator locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ the Kubernetes API. For development running Vault in dev mode is fine.
 ### Setup
 
 - The operator needs to connect to a Vault server. See this [example config](https://gist.github.com/rossf7/106fc1c97ebf24517d8be3cb30eb9a49) for running Vault as a deployment with a ClusterIP service.
-- The cert-operator binary needs to be built into a docker image and tagged as
-`quay.io/giantswarm/cert-operator:local-dev`.
+- The cert-operator binary needs to be built into a docker image and tagged as `quay.io/giantswarm/cert-operator:local-dev`. The current pod need to be deleted for changes to apply.
 
 ```
-GOOS=linux go build github.com/giantswarm/cert-operator && docker build -t quay.io/giantswarm/cert-operator:local-dev .
+GOOS=linux go build github.com/giantswarm/cert-operator \
+  && docker build -t quay.io/giantswarm/cert-operator:local-dev . \
+  && kubectl delete pod -l app=cert-operator-local
 ```
 
 - The docker image needs to be accessible from the k8s cluster. For Minikube see [reusing the docker daemon](https://github.com/kubernetes/minikube/blob/master/docs/reusing_the_docker_daemon.md).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ the Kubernetes API. For development running Vault in dev mode is fine.
 
 ### Setup
 
-- The operator needs to connect to a Vault server. See this [example config](https://gist.github.com/rossf7/106fc1c97ebf24517d8be3cb30eb9a49) for running Vault as a deployment with a ClusterIP service.
+- The operator needs to connect to a Vault server. See [examples/vault.yaml](https://github.com/giantswarm/cert-operator/blob/master/examples/api-cert.yaml) for running Vault as a deployment with a ClusterIP service.
 - The cert-operator binary needs to be built into a docker image and tagged as `quay.io/giantswarm/cert-operator:local-dev`. The current pod need to be deleted for changes to apply.
 
 ```

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ spec:
         - --service.vault.config.pki.commonname.format=%s.g8s.aws.giantswarm.io
 ```
 
-- Note: this should only be used for development. See the [/kubernetes/](https://github.com/giantswarm/cert-operator/tree/master/kubernetes)
+- Note: Edit YOUR_VAULT_HOST to point at your Vault endpoint.
+- Note: This should only be used for development. See the [/kubernetes/](https://github.com/giantswarm/cert-operator/tree/master/kubernetes)
 directory and [Secrets](https://github.com/giantswarm/cert-operator#secrets) for a production ready configuration.
 
 ### Creating TPOs (Third Party Objects)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,82 @@ go build github.com/giantswarm/cert-operator
 
 ## Running cert-operator
 
-- TBC
+The operator needs a connection to Vault (currently v0.6.4 is supported) and to
+the Kubernetes API. For development running Vault in dev mode is fine.
+
+### Setup
+
+- The operator needs to connect to a Vault server. See this [example config](https://gist.github.com/rossf7/106fc1c97ebf24517d8be3cb30eb9a49) for running Vault as a deployment with a ClusterIP service.
+- The cert-operator binary needs to be built into a docker image and tagged as
+`quay.io/giantswarm/cert-operator:local-dev`.
+
+```
+GOOS=linux go build github.com/giantswarm/cert-operator && docker build -t quay.io/giantswarm/cert-operator:local-dev .
+```
+
+- The docker image needs to be accessible from the k8s cluster. For Minikube see [reusing the docker daemon](https://github.com/kubernetes/minikube/blob/master/docs/reusing_the_docker_daemon.md).
+- The operator also needs a connection to the K8s API. The simplest approach
+is to run as a deployment and use the "in cluster" configuration.
+
+```
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cert-operator-local
+  namespace: default
+  labels:
+    app: cert-operator-local
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: cert-operator-local
+    spec:
+      volumes:
+      containers:
+      - name: cert-operator
+        image: quay.io/giantswarm/cert-operator:local-dev
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8000
+        args:
+        - daemon
+        - --service.vault.config.address=http://YOUR_VAULT_HOST:8200
+        - --service.vault.config.token=YOUR_TOKEN
+        - --service.vault.config.pki.ca.ttl=1440h
+        - --service.vault.config.pki.commonname.format=%s.g8s.aws.giantswarm.io
+```
+
+- Note: this should only be used for development. See the [/kubernetes/](https://github.com/giantswarm/cert-operator/tree/master/kubernetes)
+directory and [Secrets](https://github.com/giantswarm/cert-operator#secrets) for a production ready configuration.
+
+### Creating TPOs (Third Party Objects)
+
+- The [/examples/](https://github.com/giantswarm/cert-operator/tree/master/examples) directory contains a set of certificatetpr resources designed
+to work with the [example cluster](https://github.com/giantswarm/aws-operator/blob/master/examples/cluster.yml) in the `aws-operator`.
+
+```
+for i in examples/*-cert.yaml; do kubectl create -f $i; done
+```
+
+- The certificates are issued using Vault and stored as k8s secrets.
+
+```
+kubectl get secret -l clusterID=example-cluster
+```
+
+### Cleaning up
+
+- Delete the certificate TPOs and the deployment.
+
+```
+kubectl delete certificate -l clusterID=example-cluster
+kubectl delete deployment cert-operator-local
+```
 
 ## Contact
 

--- a/examples/api-cert.yaml
+++ b/examples/api-cert.yaml
@@ -3,6 +3,9 @@ kind: Certificate
 metadata:
   name: "example-cluster-api"
   namespace: "default"
+  labels:
+    clusterID: "example-cluster"
+    clusterComponent: "api"
 spec:
   clusterID: "example-cluster"
   clusterComponent: "api"

--- a/examples/calico-cert.yaml
+++ b/examples/calico-cert.yaml
@@ -3,6 +3,9 @@ kind: Certificate
 metadata:
   name: "example-cluster-calico"
   namespace: "default"
+  labels:
+    clusterID: "example-cluster"
+    clusterComponent: "calico"
 spec:
   clusterID: "example-cluster"
   clusterComponent: "calico"

--- a/examples/etcd-cert.yaml
+++ b/examples/etcd-cert.yaml
@@ -3,6 +3,9 @@ kind: Certificate
 metadata:
   name: "example-cluster-etcd"
   namespace: "default"
+  labels:
+    clusterID: "example-cluster"
+    clusterComponent: "etcd"
 spec:
   clusterID: "example-cluster"
   clusterComponent: "etcd"

--- a/examples/service-account-cert.yaml
+++ b/examples/service-account-cert.yaml
@@ -3,6 +3,9 @@ kind: Certificate
 metadata:
   name: "example-cluster-service-account"
   namespace: "default"
+  labels:
+    clusterID: "example-cluster"
+    clusterComponent: "service-account"
 spec:
   clusterID: "example-cluster"
   clusterComponent: "service-account"

--- a/examples/vault.yaml
+++ b/examples/vault.yaml
@@ -1,0 +1,46 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: vault
+  namespace: default
+  labels:
+    app: vault
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: vault
+    spec:
+      containers:
+        - name: vault
+          image: vault:0.6.4
+          ports:
+          - name: http
+            containerPort: 8200
+          args:
+          - server
+          - -dev
+          - -dev-root-token-id=YOUR_TOKEN
+          - -log-level=debug
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault
+  namespace: default
+  labels:
+    app: vault
+spec:
+  type: ClusterIP
+  ports:
+    - name: api
+      port: 8200
+      targetPort: http
+  selector:
+    app: vault
+  sessionAffinity: None

--- a/examples/worker-cert.yaml
+++ b/examples/worker-cert.yaml
@@ -3,6 +3,9 @@ kind: Certificate
 metadata:
   name: "example-cluster-worker"
   namespace: "default"
+  labels:
+    clusterID: "example-cluster"
+    clusterComponent: "worker"
 spec:
   clusterID: "example-cluster"
   clusterComponent: "worker"


### PR DESCRIPTION
Fixes #40 

Adds docs for running the operator locally. Also helps with running aws-operator locally as the example cert TPOs match the example cluster TPO.