### PR TITLE
Set resync period to 5 minutes to fix problem with delete watch

### DIFF
--- a/service/crt/service.go
+++ b/service/crt/service.go
@@ -28,9 +28,9 @@ const (
 	CertificateWatchAPIEndpoint string = "/apis/giantswarm.io/v1/watch/certificates"
 
 	// resyncPeriod is the period for re-synchronizing the list of objects in k8s
-	// watcher. 0 means that re-sync will be delayed as long as possible, until
-	// the watch will be closed or timed out.
-	resyncPeriod time.Duration = 0
+	// watcher. Set to 5 minutes to make the watch more robust.
+	// See https://github.com/giantswarm/cert-operator/issues/32
+	resyncPeriod time.Duration = time.Minute * 5
 )
 
 // Config represents the configuration used to create a Crt service.


### PR DESCRIPTION
See the Traefik issue and PR linked in #32

This is an attempt to fix why delete watches aren't being triggered. Sets resync period to 5 minutes. Currently this is set to 0 so it delays the resync for as long as possible.

If this fix works we need to implement in operatorkit. As this problem also happens with `aws-operator` and means we need to clean up AWS resources manually.