### PR TITLE
DNS records should match format used by API

### DIFF
--- a/examples/api-cert.yaml
+++ b/examples/api-cert.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   clusterID: "example-cluster"
   clusterComponent: "api"
-  commonName: "api.example-cluster.aws.giantswarm.io"
+  commonName: "api.example-cluster.g8s.eu-west-1.adidas.aws.giantswarm.io"
   altNames:
-  - "example-cluster.aws.giantswarm.io"
+  - "example-cluster.g8s.eu-west-1.adidas.aws.giantswarm.io"
   - "k8s-master-vm"
   - "kubernetes"
   - "kubernetes.default"

--- a/examples/calico-cert.yaml
+++ b/examples/calico-cert.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   clusterID: "example-cluster"
   clusterComponent: "calico"
-  commonName: "calico.example-cluster.aws.giantswarm.io"
+  commonName: "calico.example-cluster.g8s.eu-west-1.adidas.aws.giantswarm.io"
   altNames:
   ipSans:
   ttl: "720h"

--- a/examples/etcd-cert.yaml
+++ b/examples/etcd-cert.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   clusterID: "example-cluster"
   clusterComponent: "etcd"
-  commonName: "etcd.example-cluster.aws.giantswarm.io"
+  commonName: "etcd.example-cluster.g8s.eu-west-1.adidas.aws.giantswarm.io"
   altNames:
   ipSans:
   ttl: "720h"

--- a/examples/service-account-cert.yaml
+++ b/examples/service-account-cert.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   clusterID: "example-cluster"
   clusterComponent: "service-account"
-  commonName: "service-account.example-cluster.aws.giantswarm.io"
+  commonName: "service-account.example-cluster.g8s.eu-west-1.adidas.aws.giantswarm.io"
   altNames:
   ipSans:
   ttl: "720h"

--- a/examples/worker-cert.yaml
+++ b/examples/worker-cert.yaml
@@ -9,9 +9,9 @@ metadata:
 spec:
   clusterID: "example-cluster"
   clusterComponent: "worker"
-  commonName: "worker.example-cluster.aws.giantswarm.io"
+  commonName: "worker.example-cluster.g8s.eu-west-1.adidas.aws.giantswarm.io"
   altNames:
-  - "example-cluster.aws.giantswarm.io"
+  - "example-cluster.g8s.eu-west-1.adidas.aws.giantswarm.io"
   - "k8s-master-vm"
   - "kubernetes"
   - "kubernetes.default"


### PR DESCRIPTION
We need to remove the Route 53 hosted zones for `aws.giantswarm.io` and `aws.gigantic.io`. This PR updates the domain names to use the same format as the API.