### PR TITLE
Set allowed domains when issuing certs

### DIFF
--- a/flag/service/vault/config/certificate/certificate.go
+++ b/flag/service/vault/config/certificate/certificate.go
@@ -1,0 +1,5 @@
+package certificate
+
+type Certificate struct {
+	AllowedDomainsFormat string
+}

--- a/flag/service/vault/config/config.go
+++ b/flag/service/vault/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/giantswarm/cert-operator/flag/service/vault/config/certificate"
 	"github.com/giantswarm/cert-operator/flag/service/vault/config/pki"
 )
 
@@ -8,5 +9,6 @@ type Config struct {
 	Address string
 	Token   string
 
-	PKI pki.PKI
+	Certificate certificate.Certificate
+	PKI         pki.PKI
 }

--- a/helm/cert-operator-chart/templates/configmap.yaml
+++ b/helm/cert-operator-chart/templates/configmap.yaml
@@ -12,6 +12,8 @@ data:
       vault:
         config:
           address: '{{ .Values.Installation.V1.Auth.Vault.Address }}'
+          certificate:
+            allowedDomainsFormat: '%s.{{ .Values.Installation.V1.Guest.Kubernetes.API.EndpointBase }},kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local'
           pki:
             ca:
               ttl: '{{ .Values.Installation.V1.Auth.Vault.CA.TTL }}'

--- a/kubernetes/configmap.yaml
+++ b/kubernetes/configmap.yaml
@@ -12,6 +12,8 @@ data:
       vault:
         config:
           address: '{{ .Installation.V1.Auth.Vault.Address | urlString }}'
+          certificate:
+            allowedDomainsFormat: '%s.{{ .Values.Installation.V1.Guest.Kubernetes.API.EndpointBase }},kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local'
           pki:
             ca:
               ttl: '{{ .Installation.V1.Auth.Vault.CA.TTL | shortDuration }}'

--- a/main.go
+++ b/main.go
@@ -130,6 +130,7 @@ func main() {
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.KeyFile, "", "Key file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Vault.Config.Address, "", "Address used to connect to Vault.")
 	daemonCommand.PersistentFlags().String(f.Service.Vault.Config.Token, "", "Token used to authenticate against Vault.")
+	daemonCommand.PersistentFlags().String(f.Service.Vault.Config.Certificate.AllowedDomainsFormat, "", "Used to generate allowed domains for certificates.")
 	daemonCommand.PersistentFlags().String(f.Service.Vault.Config.PKI.CA.TTL, "", "TTL used to generate a new Cluster CA.")
 	daemonCommand.PersistentFlags().String(f.Service.Vault.Config.PKI.CommonName.Format, "", "Common name used to generate a new Cluster CA.")
 


### PR DESCRIPTION
This fix adds the allowed domains when issuing certs so the vault role is correct.