### PR TITLE
add allowed domains format option to local example's deployment

### DIFF
--- a/examples/local/deployment.tmpl.yaml
+++ b/examples/local/deployment.tmpl.yaml
@@ -28,3 +28,4 @@ spec:
         - --service.vault.config.token=${VAULT_TOKEN}
         - --service.vault.config.pki.ca.ttl=1440h
         - --service.vault.config.pki.commonname.format=%s.${COMMON_DOMAIN}
+        - --service.vault.config.certificate.alloweddomainsformat=%s.${COMMON_DOMAIN},k8s-master-vm,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster.local


### PR DESCRIPTION
Without this the certificate TPOs weren't being created. It started with a failure about empty allowed domains:
```
{"caller":"github.com/giantswarm/cert-operator/service/crt/service.go:155","error":"could not issue cert '[{/home/fgimenez/workspace/gocode/src/github.com/giantswarm/cert-operator/service/crt/cert_signer.go:31: } {/home/fgimenez/workspace/gocode/src/github.com/giantswarm/cert-operator/service/crt/cert_signer.go:54: certificate allowed domains must not be empty} {invalid config}]'","time":"17-09-07 08:22:01.305"}
```
i've been adding them later on following the failures, for instance:
```
{"caller":"github.com/giantswarm/cert-operator/service/crt/service.go:155","error":"could not issue cert '[{/home/fgimenez/workspace/gocode/src/github.com/giantswarm/cert-operator/service/crt/cert_signer.go:31: } {/home/fgimenez/workspace/gocode/src/github.com/giantswarm/cert-operator/service/crt/cert_signer.go:70: } {/home/fgimenez/workspace/gocode/src/github.com/giantswarm/cert-operator/vendor/github.com/giantswarm/certctl/service/cert-signer/cert_signer.go:101: } {Error making API request.\n\nURL: PUT http://vault:8200/v1/pki-g8s/issue/role-g8s\nCode: 400. Errors:\n\n* name k8s-master-vm not allowed by this role}]'","time":"17-09-07 11:43:39.167"}
```
