### PR TITLE
add scripts to automate the setup and teardown of the local example

### DIFF
--- a/examples/local/env.sh
+++ b/examples/local/env.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-export CLUSTER_NAME=g8s
-export COMMON_DOMAIN=local
-export VAULT_HOST=vault
-export VAULT_TOKEN=mytoken
+export CLUSTER_NAME=${CLUSTER_NAME:-g8s}
+export COMMON_DOMAIN=${COMMON_DOMAIN:-local}
+export VAULT_HOST=${VAULT_HOST:-vault}
+export VAULT_TOKEN=${VAULT_TOKEN:-mytoken}

--- a/examples/local/env.sh
+++ b/examples/local/env.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 export CLUSTER_NAME=g8s
-export COMMON_DOMAIN=${CLUSTER_NAME}.local
+export COMMON_DOMAIN=local
 export VAULT_HOST=vault
 export VAULT_TOKEN=mytoken

--- a/examples/local/env.sh
+++ b/examples/local/env.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+export CLUSTER_NAME=g8s
+export COMMON_DOMAIN=${CLUSTER_NAME}.local
+export VAULT_HOST=vault
+export VAULT_TOKEN=mytoken

--- a/examples/local/setup-minikube.sh
+++ b/examples/local/setup-minikube.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -ex
+
+. ./env.sh
+
+for f in *.tmpl.yaml; do
+    sed \
+        -e 's|${CLUSTER_NAME}|'"${CLUSTER_NAME}"'|g' \
+        -e 's|${COMMON_DOMAIN}|'"${COMMON_DOMAIN}"'|g' \
+        -e 's|${VAULT_HOST}|'"${VAULT_HOST}"'|g' \
+        -e 's|${VAULT_TOKEN}|'"${VAULT_TOKEN}"'|g' \
+        ./$f > ./${f%.tmpl.yaml}.yaml
+done
+
+kubectl apply -f ./vault.yaml
+eval $(minikube docker-env)
+(
+    cd ../..
+    CGO_ENABLED=0 GOOS=linux go build github.com/giantswarm/cert-operator
+    docker build -t quay.io/giantswarm/cert-operator:local-dev .
+)
+
+kubectl apply -f ./deployment.yaml
+
+for f in *-cert.yaml; do
+    kubectl create -f ./$f
+done

--- a/examples/local/setup-minikube.sh
+++ b/examples/local/setup-minikube.sh
@@ -17,7 +17,7 @@ kubectl apply -f ./vault.yaml
 eval $(minikube docker-env)
 (
     cd ../..
-    CGO_ENABLED=0 GOOS=linux go build github.com/giantswarm/cert-operator
+    CGO_ENABLED=0 GOOS=linux go build .
     docker build -t quay.io/giantswarm/cert-operator:local-dev .
 )
 

--- a/examples/local/teardown.sh
+++ b/examples/local/teardown.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -ex
+
+. ./env.sh
+
+kubectl delete certificate -l clusterID=${CLUSTER_NAME}
+kubectl delete -f ./deployment.yaml
+kubectl delete -f ./vault.yaml


### PR DESCRIPTION
The setup script is specific for minikube, maybe this could be configured.