### PR TITLE
set ipSans for the api cert in local example

### DIFF
--- a/examples/local/api-cert.tmpl.yaml
+++ b/examples/local/api-cert.tmpl.yaml
@@ -18,5 +18,6 @@ spec:
   - "kubernetes.default.svc"
   - "kubernetes.default.svc.cluster.local"
   ipSans:
+  - "172.31.0.1"
   ttl: "720h"
   allowBareDomains: true


### PR DESCRIPTION
This will prevent errors in guest cluster's ingress controller:
```
$ kubectl get pods --all-namespaces
NAMESPACE     NAME                                        READY     STATUS             RESTARTS   AGE
kube-system   calico-node-fbtps                           2/2       Running            0          11m
kube-system   calico-node-nd13n                           2/2       Running            4          11m
kube-system   calico-node-v256n                           2/2       Running            5          11m
kube-system   calico-policy-controller-1843598625-th5nw   1/1       Running            4          11m
kube-system   default-http-backend-2945164050-kxfxr       1/1       Running            0          11m
kube-system   default-http-backend-2945164050-p46k7       1/1       Running            0          11m
kube-system   kube-dns-1228971746-fg0dv                   3/3       Running            0          11m
kube-system   kube-dns-1228971746-hmq7p                   3/3       Running            0          11m
kube-system   kube-dns-1228971746-rwfmg                   3/3       Running            0          11m
kube-system   nginx-ingress-controller-1637951549-2tll9   0/1       CrashLoopBackOff   6          11m
kube-system   nginx-ingress-controller-1637951549-74skw   0/1       CrashLoopBackOff   6          11m
$ kubectl logs nginx-ingress-controller-1637951549-2tll9 -n kube-system
[dumb-init] Unable to detach from controlling tty (errno=25 Inappropriate ioctl for device).
[dumb-init] Child spawned with PID 5.
[dumb-init] Unable to attach to controlling tty (errno=25 Inappropriate ioctl for device).
[dumb-init] setsid complete.
I0908 12:22:08.296381       5 launch.go:105] &{NGINX 0.9.0-beta.11 git-a3131c5 https://github.com/kubernetes/ingress}
I0908 12:22:08.296500       5 launch.go:108] Watching for ingress class: nginx
I0908 12:22:08.296704       5 launch.go:262] Creating API server client for https://172.31.0.1:443
I0908 12:22:08.312978       5 nginx.go:182] starting NGINX process...
F0908 12:22:08.317949       5 launch.go:122] no service with name kube-system/default-http-backend found: Get https://172.31.0.1:443/api/v1/namespaces/kube-system/services/default-http-backend: x509: cannot validate certificate for 172.31.0.1 because it doesn't contain any IP SANs
[dumb-init] Received signal 17.
[dumb-init] A child with PID 5 exited with exit status 255.
[dumb-init] Forwarded signal 15 to children.
[dumb-init] Child exited with status 255. Goodbye.
```
For now hardcoding the value for consistency with aws-operator's templates, maybe this could be interpolated from an env var in both cases.