### PR TITLE
Add namespace handling

### DIFF
--- a/service/key/key.go
+++ b/service/key/key.go
@@ -39,6 +39,10 @@ func SecretName(customObject certificatetpr.CustomObject) string {
 	return fmt.Sprintf("%s-%s", ClusterID(customObject), ClusterComponent(customObject))
 }
 
+func SecretNamespace(customObject certificatetpr.CustomObject) string {
+	return customObject.Spec.SecretNamespace
+}
+
 func RoleTTL(customObject certificatetpr.CustomObject) string {
 	return customObject.Spec.TTL
 }

--- a/service/resource/vaultcrt/create.go
+++ b/service/resource/vaultcrt/create.go
@@ -65,7 +65,12 @@ func (r *Resource) ProcessCreateState(ctx context.Context, obj, createState inte
 	if secretToCreate != nil {
 		r.logger.Log("cluster", key.ClusterID(customObject), "debug", "creating the secret in the Kubernetes API")
 
-		_, err := r.k8sClient.CoreV1().Secrets(r.namespace).Create(secretToCreate)
+		ns := key.SecretNamespace(customObject)
+		if ns == "" {
+			ns = r.namespace
+		}
+
+		_, err := r.k8sClient.CoreV1().Secrets(ns).Create(secretToCreate)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/resource/vaultcrt/current.go
+++ b/service/resource/vaultcrt/current.go
@@ -21,7 +21,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	var secret *apiv1.Secret
 	{
-		manifest, err := r.k8sClient.Core().Secrets(r.namespace).Get(key.SecretName(customObject), apismetav1.GetOptions{})
+		ns := key.SecretNamespace(customObject)
+		if ns == "" {
+			ns = r.namespace
+		}
+
+		manifest, err := r.k8sClient.Core().Secrets(ns).Get(key.SecretName(customObject), apismetav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			r.logger.Log("cluster", key.ClusterID(customObject), "debug", "did not find the secret in the Kubernetes API")
 			// fall through

--- a/service/resource/vaultcrt/delete.go
+++ b/service/resource/vaultcrt/delete.go
@@ -46,7 +46,12 @@ func (r *Resource) ProcessDeleteState(ctx context.Context, obj, deleteState inte
 	if secretToDelete != nil {
 		r.logger.Log("cluster", key.ClusterID(customObject), "debug", "deleting the sercet in the Kubernetes API")
 
-		err = r.k8sClient.CoreV1().Secrets(r.namespace).Delete(secretToDelete.Name, &apismetav1.DeleteOptions{})
+		ns := key.SecretNamespace(customObject)
+		if ns == "" {
+			ns = r.namespace
+		}
+
+		err = r.k8sClient.CoreV1().Secrets(ns).Delete(secretToDelete.Name, &apismetav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
 			// fall through
 		} else if err != nil {

--- a/vendor/github.com/giantswarm/certificatetpr/service.go
+++ b/vendor/github.com/giantswarm/certificatetpr/service.go
@@ -10,7 +10,6 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
@@ -88,7 +87,7 @@ func (s *Service) SearchCerts(clusterID string) (AssetsBundle, error) {
 func (s *Service) SearchCertsForComponent(clusterID, componentName string) (AssetsBundle, error) {
 	// TODO we should also do a list. In case the secrets have already been
 	// created we might miss them with only watching.
-	watcher, err := s.k8sClient.Core().Secrets(api.NamespaceDefault).Watch(apismetav1.ListOptions{
+	watcher, err := s.k8sClient.Core().Secrets("").Watch(apismetav1.ListOptions{
 		// Select only secrets that match the given component and the given cluster
 		// clusterID.
 		LabelSelector: fmt.Sprintf(

--- a/vendor/github.com/giantswarm/certificatetpr/spec.go
+++ b/vendor/github.com/giantswarm/certificatetpr/spec.go
@@ -11,5 +11,6 @@ type Spec struct {
 	ClusterID        string   `json:"clusterID" yaml:"clusterID"`
 	CommonName       string   `json:"commonName" yaml:"commonName"`
 	IPSANs           []string `json:"ipSans" yaml:"ipSans"`
+	SecretNamespace  string   `json:"secretNamespace" yaml:"secretNamespace"`
 	TTL              string   `json:"ttl" yaml:"ttl"`
 }

--- a/vendor/github.com/giantswarm/certificatetpr/spec_test.go
+++ b/vendor/github.com/giantswarm/certificatetpr/spec_test.go
@@ -25,7 +25,8 @@ func TestSpecYamlEncoding(t *testing.T) {
 		IPSANs: []string{
 			"172.31.0.1",
 		},
-		TTL: "4320h",
+		SecretNamespace: "default",
+		TTL:             "4320h",
 	}
 
 	var got map[string]interface{}


### PR DESCRIPTION
Tests will fail due to not vendored certificatetpr. https://github.com/giantswarm/certificatetpr/pull/29

If secret namespace set in TPO then use one
if not then use defalt.

Partly implements: https://github.com/giantswarm/cert-operator/issues/95
Depends on: https://github.com/giantswarm/certificatetpr/pull/29