### PR TITLE
Set allow bare domains to true for worker cert

### DIFF
--- a/examples/cert-resource-lab-chart/templates/worker-cert.yaml
+++ b/examples/cert-resource-lab-chart/templates/worker-cert.yaml
@@ -19,4 +19,4 @@ spec:
   - "kubernetes.default.svc.cluster.local"
   ipSans:
   ttl: "720h"
-  allowBareDomains: false
+  allowBareDomains: true


### PR DESCRIPTION
Fixes a bug with the local setup. Flag needs to be true because kubernetes and k8s-master-vm are alt names for the cert.