### PR TITLE
removed finalizer

### DIFF
--- a/service/framework.go
+++ b/service/framework.go
@@ -568,9 +568,9 @@ func migrateTPRsToCRDs(logger micrologger.Logger, clientSet *versioned.Clientset
 			cro.TypeMeta.APIVersion = "core.giantswarm.io"
 			cro.TypeMeta.Kind = "CertConfig"
 			cro.ObjectMeta.Name = tpo.Name
-			cro.ObjectMeta.Finalizers = []string{
-				CertConfigCleanupFinalizer,
-			}
+			//cro.ObjectMeta.Finalizers = []string{
+			//	CertConfigCleanupFinalizer,
+			//}
 			cro.Spec.Cert.AllowBareDomains = tpo.Spec.AllowBareDomains
 			cro.Spec.Cert.AltNames = tpo.Spec.AltNames
 			cro.Spec.Cert.ClusterComponent = tpo.Spec.ClusterComponent


### PR DESCRIPTION
I noticed that finalizers in our installations behave differently than when I tested back then on my minikube. For now it is safer to just drop them and manage the finalizer logic separately in a unified way.