### PR TITLE
e2e: use localkube

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,39 +18,21 @@ jobs:
             ./architect deploy
           fi
 
-  e2eSetup:
+  e2eTestExecution:
     machine: true
+    working_directory: /home/circleci/.go_workspace/src/github.com/giantswarm/cert-operator
+    environment:
+      MINIKUBE_VERSION: v0.25.0
     steps:
     - checkout
-
-    - attach_workspace:
-        at: .
 
     - run: |
         wget -q $(curl -sS https://api.github.com/repos/giantswarm/e2e-harness/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
         chmod +x ./e2e-harness
 
-    - run: ./e2e-harness setup --name=ci-certop-${CIRCLE_SHA1:0:7}
+    - run: ./e2e-harness localkube
 
-    - run:
-        name: Cleanup on failure
-        command: ./e2e-harness teardown
-        when: on_fail
-
-    - persist_to_workspace:
-        root: .
-        paths:
-        - ./e2e-harness
-        - ./.e2e-harness
-
-  e2eTestExecution:
-    machine: true
-    working_directory: /home/circleci/.go_workspace/src/github.com/giantswarm/cert-operator
-    steps:
-    - checkout
-
-    - attach_workspace:
-        at: .
+    - run: ./e2e-harness setup --remote=false
 
     - run: ./e2e-harness test
 
@@ -64,8 +46,6 @@ workflows:
   build_e2e:
     jobs:
       - build
-      - e2eSetup
       - e2eTestExecution:
           requires:
           - build
-          - e2eSetup


### PR DESCRIPTION
Uses localkube (minikube with `--vm-driver=none`) from e2e-harness. This way minikube is run on circleCI machines and we don't need to spin up an AWS instance for each e2e execution. Also the setup is slightly quicker.