### PR TITLE
reconcile empty version bundle version to support legacy secrets

### DIFF
--- a/service/certconfig/framework.go
+++ b/service/certconfig/framework.go
@@ -149,6 +149,7 @@ func NewFramework(config FrameworkConfig) (*framework.Framework, error) {
 
 			ExpirationThreshold: config.ExpirationThreshold,
 			HandledVersionBundles: []string{
+				"",
 				"0.1.0",
 			},
 			Name:      config.Name,


### PR DESCRIPTION
We come closer to situations in which the oldest guest clusters run on expired certificates. Back then we created cert configs that do not obtain any version bundle version. This PR makes the certificates at least to be renewed so in case we get into another situation like this we have one reason less to worry. 