### PR TITLE
Update vaultrole dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -200,7 +200,7 @@
     "key",
     "vaultroletest"
   ]
-  revision = "277001d5f551cfad1dfa15b19ddaea97e24e5cda"
+  revision = "7dadda42ea524a63d053f3fb362c90f73119c0e6"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -200,7 +200,7 @@
     "key",
     "vaultroletest"
   ]
-  revision = "7dadda42ea524a63d053f3fb362c90f73119c0e6"
+  revision = "735d5b6ddd72cf8d8d67d9c8c94b6fd7e7c350a7"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/giantswarm/vaultrole/current.go
+++ b/vendor/github.com/giantswarm/vaultrole/current.go
@@ -1,9 +1,8 @@
 package vaultrole
 
 import (
-	"encoding/json"
-
 	"github.com/giantswarm/microerror"
+	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/helper/parseutil"
 
 	"github.com/giantswarm/vaultrole/key"
@@ -39,14 +38,6 @@ func (r *VaultRole) Exists(config ExistsConfig) (bool, error) {
 	return false, nil
 }
 
-type role struct {
-	AllowBareDomains bool   `json:"allow_bare_domains"`
-	AllowSubdomains  bool   `json:"allow_subdomains"`
-	AllowedDomains   string `json:"allowed_domains"`
-	Organizations    string `json:"organization"` // NOTE the singular form here.
-	TTL              string `json:"ttl"`
-}
-
 func (r *VaultRole) Search(config SearchConfig) (Role, error) {
 	// Check if a PKI for the given cluster ID exists.
 	secret, err := r.vaultClient.Logical().Read(key.ReadRolePath(config.ID, config.Organizations))
@@ -61,32 +52,111 @@ func (r *VaultRole) Search(config SearchConfig) (Role, error) {
 		return Role{}, microerror.Maskf(notFoundError, "no vault secret at path '%s'", key.RoleName(config.ID, config.Organizations))
 	}
 
-	b, err := json.Marshal(secret.Data)
+	role, err := vaultSecretToRole(secret)
 	if err != nil {
 		return Role{}, microerror.Mask(err)
 	}
 
-	var internalRole role
-	err = json.Unmarshal(b, &internalRole)
-	if err != nil {
-		return Role{}, microerror.Mask(err)
+	role.ID = config.ID
+	return role, nil
+}
+
+// vaultSecretToRole makes required type casts / type checks and parsing to
+// extract role information from Vault api.Secret.
+func vaultSecretToRole(secret *api.Secret) (Role, error) {
+	var role Role
+
+	{
+		v, exists := secret.Data["allow_bare_domains"]
+		if !exists {
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "allow_bare_domains missing from Vault api.Secret.Data")
+		}
+
+		allowBareDomains, ok := v.(bool)
+		if !ok {
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "Vault secret.Data[\"allow_bare_domains\"] type is %T, expected %T", secret.Data["allow_bare_domains"], allowBareDomains)
+		}
+
+		role.AllowBareDomains = allowBareDomains
 	}
 
-	altNames := key.ToAltNames(internalRole.AllowedDomains)
-	organizations := key.ToOrganizations(internalRole.Organizations)
-	ttl, err := parseutil.ParseDurationSecond(internalRole.TTL)
-	if err != nil {
-		return Role{}, microerror.Mask(err)
+	{
+		v, exists := secret.Data["allow_subdomains"]
+		if !exists {
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "allow_subdomains missing from Vault api.Secret.Data")
+		}
+
+		allowSubdomains, ok := v.(bool)
+		if !ok {
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "Vault secret.Data[\"allow_subdomains\"] type is %T, expected %T", secret.Data["allow_subdomains"], allowSubdomains)
+		}
+
+		role.AllowSubdomains = allowSubdomains
 	}
 
-	newRole := Role{
-		AllowBareDomains: internalRole.AllowBareDomains,
-		AllowSubdomains:  internalRole.AllowSubdomains,
-		AltNames:         altNames,
-		ID:               config.ID,
-		Organizations:    organizations,
-		TTL:              ttl,
+	{
+		allowedDomains, exists := secret.Data["allowed_domains"]
+		if !exists {
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "allowed_domains missing from Vault api.Secret.Data")
+		}
+
+		// Types in secret.Data["allowed_domains"] differ between versions of
+		// Vault / configuration of g8s. Try couple different formats before
+		// returning error.
+		switch v := allowedDomains.(type) {
+		case string:
+			role.AltNames = key.ToAltNames(v)
+		case []string:
+			role.AltNames = v[1:]
+		case []interface{}:
+			allowedDomains := make([]string, 0, len(v))
+			for i, val := range v {
+				if s, ok := val.(string); ok {
+					allowedDomains = append(allowedDomains, s)
+				} else {
+					return Role{}, microerror.Maskf(invalidVaultResponseError, "Vault secret.Data[\"allowed_domains\"][%d] has unexpected type '%T'. It's not string nor []string.", i, val)
+				}
+			}
+
+			// TODO: Why first one is dropped (this was in key.ToAltNames()?
+			role.AltNames = allowedDomains[1:]
+		default:
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "Vault secret.Data[\"allowed_domains\"] type is '%T'. It's not string, []string nor []interface{} (masking strings).", secret.Data["allowed_domains"])
+		}
 	}
 
-	return newRole, nil
+	{
+		v, exists := secret.Data["organization"]
+		if !exists {
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "organization missing from Vault api.Secret.Data")
+		}
+
+		organization, ok := v.(string)
+		if !ok {
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "Vault secret.Data[\"organization\"] type is %T, expected %T", secret.Data["organization"], organization)
+		}
+
+		role.Organizations = key.ToOrganizations(organization)
+	}
+
+	{
+		v, exists := secret.Data["ttl"]
+		if !exists {
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "ttl missing from Vault api.Secret.Data")
+		}
+
+		ttlStr, ok := v.(string)
+		if !ok {
+			return Role{}, microerror.Maskf(invalidVaultResponseError, "Vault secret.Data[\"ttl\"] type is %T, expected %T", secret.Data["ttl"], ttlStr)
+		}
+
+		ttl, err := parseutil.ParseDurationSecond(ttlStr)
+		if err != nil {
+			return Role{}, microerror.Mask(err)
+		}
+
+		role.TTL = ttl
+	}
+
+	return role, nil
 }

--- a/vendor/github.com/giantswarm/vaultrole/error.go
+++ b/vendor/github.com/giantswarm/vaultrole/error.go
@@ -20,6 +20,13 @@ func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
+var invalidVaultResponseError = microerror.New("invalid vault response")
+
+// IsInvalidVaultResponse asserts invalidVaultResponseError
+func IsInvalidVaultResponse(err error) bool {
+	return microerror.Cause(err) == invalidVaultResponseError
+}
+
 var notFoundError = microerror.New("not found")
 
 // IsNotFound asserts notFoundError.


### PR DESCRIPTION
New Vault release (at least for us 0.9.3) brought changes in its API for
certificate AltName formatting. New vaultrole dependency has fixes for
this.