### PR TITLE
Add listing pods to RBAC role

### DIFF
--- a/helm/cert-operator-chart/templates/rbac.yaml
+++ b/helm/cert-operator-chart/templates/rbac.yaml
@@ -27,6 +27,7 @@ rules:
       - pods
     verbs:
       - get
+      - list
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
Last time I've added `get` only. Now also adding `list`.

See: https://github.com/giantswarm/cert-operator/pull/177