### PR TITLE
increase-expiration-threshold

### DIFF
--- a/helm/cert-operator-chart/templates/configmap.yaml
+++ b/helm/cert-operator-chart/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
           keyFile: ''
       resource:
         vaultCrt:
-          expirationThreshold: '14d'
+          expirationThreshold: '576h'
           namespace: 'default'
       vault:
         config:

--- a/helm/cert-operator-chart/templates/configmap.yaml
+++ b/helm/cert-operator-chart/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
           keyFile: ''
       resource:
         vaultCrt:
-          expirationThreshold: '576h'
+          expirationThreshold: '336h'
           namespace: 'default'
       vault:
         config:

--- a/helm/cert-operator-chart/templates/configmap.yaml
+++ b/helm/cert-operator-chart/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
           keyFile: ''
       resource:
         vaultCrt:
-          expirationThreshold: '24h'
+          expirationThreshold: '14d'
           namespace: 'default'
       vault:
         config:


### PR DESCRIPTION
24h is too low as we need to roll out and communication to a customer can take some extra time.

There isn't any harm in regenerating sooner.