### PR TITLE
move-namespace-to-values

### DIFF
--- a/helm/cert-operator-chart/templates/configmap.yaml
+++ b/helm/cert-operator-chart/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cert-operator-configmap
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}
 data:
   config.yaml: |
     server:

--- a/helm/cert-operator-chart/templates/deployment.yaml
+++ b/helm/cert-operator-chart/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: cert-operator
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}
   labels:
     app: cert-operator
 spec:

--- a/helm/cert-operator-chart/templates/pull-secret.yml
+++ b/helm/cert-operator-chart/templates/pull-secret.yml
@@ -3,6 +3,6 @@ kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
   name: cert-operator-pull-secret
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}
 data:
   .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}

--- a/helm/cert-operator-chart/templates/rbac.yaml
+++ b/helm/cert-operator-chart/templates/rbac.yaml
@@ -64,7 +64,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: cert-operator
-    namespace: giantswarm
+    namespace: {{ .Values.namespace }}
 roleRef:
   kind: ClusterRole
   name: cert-operator
@@ -91,7 +91,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: cert-operator
-    namespace: giantswarm
+    namespace: {{ .Values.namespace }}
 roleRef:
   kind: ClusterRole
   name: cert-operator-psp

--- a/helm/cert-operator-chart/templates/secret.yml
+++ b/helm/cert-operator-chart/templates/secret.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cert-operator-secret
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}
 type: Opaque
 data:
   secret.yaml: {{ .Values.Installation.V1.Secret.CertOperator.SecretYaml | b64enc | quote }}

--- a/helm/cert-operator-chart/templates/service-account.yaml
+++ b/helm/cert-operator-chart/templates/service-account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cert-operator
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}

--- a/helm/cert-operator-chart/templates/service.yaml
+++ b/helm/cert-operator-chart/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cert-operator
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}
   labels:
     app: cert-operator
   annotations:

--- a/helm/cert-operator-chart/values.yaml
+++ b/helm/cert-operator-chart/values.yaml
@@ -1,0 +1,1 @@
+namespace: giantswarm


### PR DESCRIPTION
in order to be able change namespace where operator is installed we need to template the namespace in the manifest, this is for kvm e2e