### PR TITLE
Update microkit dep & enable debug server

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -121,7 +121,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:310f40b39fafa31cfb2120c87ef28292ae24f8ce746a7b851845e6832bd3884e"
+  digest = "1:5c1520d3b53997d03f3848c91bca0e982701f1589a69917ba4a9e553910a2b64"
   name = "github.com/giantswarm/microkit"
   packages = [
     "command",
@@ -129,6 +129,8 @@
     "command/daemon/flag",
     "command/daemon/flag/config",
     "command/daemon/flag/server",
+    "command/daemon/flag/server/enable",
+    "command/daemon/flag/server/enable/debug",
     "command/daemon/flag/server/listen",
     "command/daemon/flag/server/log",
     "command/daemon/flag/server/tls",
@@ -138,7 +140,7 @@
     "tls",
   ]
   pruneopts = "UT"
-  revision = "ce14380d3198ff00c82888ee3ed7e9d0efaa383a"
+  revision = "21181e2cc3c8f5ce7aa32dfdd38aa11643a0a5bf"
 
 [[projects]]
   branch = "master"

--- a/helm/cert-operator-chart/templates/configmap.yaml
+++ b/helm/cert-operator-chart/templates/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
 data:
   config.yaml: |
     server:
+      enable:
+        debug:
+          server: true
       listen:
         address: 'http://0.0.0.0:8000'
     service:

--- a/vendor/github.com/giantswarm/microkit/command/daemon/command.go
+++ b/vendor/github.com/giantswarm/microkit/command/daemon/command.go
@@ -58,7 +58,7 @@ func New(config Config) (Command, error) {
 
 	newCommand.cobraCommand.PersistentFlags().StringSlice(f.Config.Dirs, []string{"."}, "List of config file directories.")
 	newCommand.cobraCommand.PersistentFlags().StringSlice(f.Config.Files, []string{"config"}, "List of the config file names. All viper supported extensions can be used.")
-
+	newCommand.cobraCommand.PersistentFlags().Bool(f.Server.Enable.Debug.Server, false, "Enable debug server at http://127.0.0.1:6060/debug.")
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.Listen.Address, "http://127.0.0.1:8000", "Address used to make the server listen to.")
 	newCommand.cobraCommand.PersistentFlags().String(f.Server.Listen.MetricsAddress, "", "Optional alternate address to expose metrics on at /metrics. Leave blank to use the default server (listen address above).")
 	newCommand.cobraCommand.PersistentFlags().Bool(f.Server.Log.Access, false, "Whether to emit logs for each requested route.")
@@ -103,6 +103,7 @@ func (c *command) Execute(cmd *cobra.Command, args []string) {
 	{
 		serverConfig := c.serverFactory(c.viper).Config()
 
+		serverConfig.EnableDebugServer = c.viper.GetBool(f.Server.Enable.Debug.Server)
 		serverConfig.LogAccess = c.viper.GetBool(f.Server.Log.Access)
 		if serverConfig.ListenAddress == "" {
 			serverConfig.ListenAddress = c.viper.GetString(f.Server.Listen.Address)

--- a/vendor/github.com/giantswarm/microkit/command/daemon/flag/server/enable/debug/debug.go
+++ b/vendor/github.com/giantswarm/microkit/command/daemon/flag/server/enable/debug/debug.go
@@ -1,0 +1,5 @@
+package debug
+
+type Debug struct {
+	Server string
+}

--- a/vendor/github.com/giantswarm/microkit/command/daemon/flag/server/enable/enable.go
+++ b/vendor/github.com/giantswarm/microkit/command/daemon/flag/server/enable/enable.go
@@ -1,0 +1,7 @@
+package enable
+
+import "github.com/giantswarm/microkit/command/daemon/flag/server/enable/debug"
+
+type Enable struct {
+	Debug debug.Debug
+}

--- a/vendor/github.com/giantswarm/microkit/command/daemon/flag/server/server.go
+++ b/vendor/github.com/giantswarm/microkit/command/daemon/flag/server/server.go
@@ -1,12 +1,14 @@
 package server
 
 import (
+	"github.com/giantswarm/microkit/command/daemon/flag/server/enable"
 	"github.com/giantswarm/microkit/command/daemon/flag/server/listen"
 	"github.com/giantswarm/microkit/command/daemon/flag/server/log"
 	"github.com/giantswarm/microkit/command/daemon/flag/server/tls"
 )
 
 type Server struct {
+	Enable enable.Enable
 	Listen listen.Listen
 	Log    log.Log
 	TLS    tls.TLS


### PR DESCRIPTION
Added debug server exposes net/http/pprof interface in
http://127.0.0.1:6060/debug.

This helps with profiling running service e.g. when it's OOMing.

Towards https://github.com/giantswarm/giantswarm/issues/4088