### PR TITLE
Add CRD label selector for e2e tests

### DIFF
--- a/flag/service/crd/crd.go
+++ b/flag/service/crd/crd.go
@@ -1,0 +1,5 @@
+package crd
+
+type CRD struct {
+	LabelSelector string
+}

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -1,12 +1,14 @@
 package service
 
 import (
+	"github.com/giantswarm/cert-operator/flag/service/crd"
 	"github.com/giantswarm/cert-operator/flag/service/kubernetes"
 	"github.com/giantswarm/cert-operator/flag/service/resource"
 	"github.com/giantswarm/cert-operator/flag/service/vault"
 )
 
 type Service struct {
+	CRD        crd.CRD
 	Kubernetes kubernetes.Kubernetes
 	Resource   resource.Resource
 	Vault      vault.Vault

--- a/helm/cert-operator-chart/templates/configmap.yaml
+++ b/helm/cert-operator-chart/templates/configmap.yaml
@@ -12,6 +12,8 @@ data:
       listen:
         address: 'http://0.0.0.0:8000'
     service:
+      crd:
+        labelSelector: '{{ .Values.labelSelector }}'
       kubernetes:
         address: ''
         inCluster: true

--- a/helm/cert-operator-chart/templates/configmap.yaml
+++ b/helm/cert-operator-chart/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
         address: 'http://0.0.0.0:8000'
     service:
       crd:
-        labelSelector: '{{ .Values.labelSelector }}'
+        labelSelector: '{{ .Values.service.crd.labelSelector }}'
       kubernetes:
         address: ''
         inCluster: true

--- a/helm/cert-operator-chart/values.yaml
+++ b/helm/cert-operator-chart/values.yaml
@@ -1,1 +1,2 @@
+labelSelector: ''
 namespace: giantswarm

--- a/helm/cert-operator-chart/values.yaml
+++ b/helm/cert-operator-chart/values.yaml
@@ -1,2 +1,4 @@
-labelSelector: ''
 namespace: giantswarm
+service:
+  crd:
+    labelSelector: ''

--- a/main.go
+++ b/main.go
@@ -99,6 +99,8 @@ func main() {
 
 	daemonCommand := newCommand.DaemonCommand().CobraCommand()
 
+	daemonCommand.PersistentFlags().String(f.Service.CRD.LabelSelector, "", "Label selector for CRD informer ListOptions.")
+
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.Address, "http://127.0.0.1:6443", "Address used to connect to Kubernetes. When empty in-cluster config is created.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Kubernetes.InCluster, false, "Whether to use the in-cluster config to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CAFile, "", "Certificate authority file path to use to authenticate with Kubernetes.")

--- a/service/controller/cert.go
+++ b/service/controller/cert.go
@@ -15,6 +15,7 @@ import (
 	"github.com/giantswarm/vaultrole"
 	vaultapi "github.com/hashicorp/vault/api"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/cert-operator/service/controller/v2"
@@ -28,10 +29,19 @@ type CertConfig struct {
 	VaultClient  *vaultapi.Client
 
 	CATTL               string
+	CRDLabelSelector    string
 	CommonNameFormat    string
 	ExpirationThreshold time.Duration
 	Namespace           string
 	ProjectName         string
+}
+
+func (c CertConfig) newInformerListOptions() metav1.ListOptions {
+	listOptions := metav1.ListOptions{
+		LabelSelector: c.CRDLabelSelector,
+	}
+
+	return listOptions
 }
 
 type Cert struct {
@@ -136,6 +146,7 @@ func NewCert(config CertConfig) (*Cert, error) {
 			Logger:  config.Logger,
 			Watcher: config.G8sClient.CoreV1alpha1().CertConfigs(""),
 
+			ListOptions:  config.newInformerListOptions(),
 			RateWait:     informer.DefaultRateWait,
 			ResyncPeriod: informer.DefaultResyncPeriod,
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -128,6 +128,7 @@ func New(config Config) (*Service, error) {
 			VaultClient:  vaultClient,
 
 			CATTL:               config.Viper.GetString(config.Flag.Service.Vault.Config.PKI.CA.TTL),
+			CRDLabelSelector:    config.Viper.GetString(config.Flag.Service.CRD.LabelSelector),
 			CommonNameFormat:    config.Viper.GetString(config.Flag.Service.Vault.Config.PKI.CommonName.Format),
 			ExpirationThreshold: config.Viper.GetDuration(config.Flag.Service.Resource.VaultCrt.ExpirationThreshold),
 			Namespace:           config.Viper.GetString(config.Flag.Service.Resource.VaultCrt.Namespace),


### PR DESCRIPTION
On KVM e2e tests there are multiple instances of operators running at
the same time. In order to prevent race conditions, add label selector
to informer to only process CRs meant for current instance of operator.

Towards https://github.com/giantswarm/giantswarm/issues/4196#issuecomment-421297710