### PR TITLE
Skip checking running pods when deleting non-supporting certconfigs.

### DIFF
--- a/service/controller/v2/key/key.go
+++ b/service/controller/v2/key/key.go
@@ -24,6 +24,10 @@ func AltNames(customObject v1alpha1.CertConfig) []string {
 	return customObject.Spec.Cert.AltNames
 }
 
+func ClusterComponent(customObject v1alpha1.CertConfig) string {
+	return customObject.Spec.Cert.ClusterComponent
+}
+
 func ClusterID(customObject v1alpha1.CertConfig) string {
 	return customObject.Spec.Cert.ClusterID
 }

--- a/service/controller/v2/key/key_test.go
+++ b/service/controller/v2/key/key_test.go
@@ -95,3 +95,19 @@ func TestOrganizationCapacity(t *testing.T) {
 		t.Errorf("customObject organizations changed by sorting an unrelated slice, expected %s, actual %s", expected, actual)
 	}
 }
+
+func TestClusterComponent(t *testing.T) {
+	expectedClusterComponent := "calico"
+
+	obj := v1alpha1.CertConfig{
+		Spec: v1alpha1.CertConfigSpec{
+			Cert: v1alpha1.CertConfigSpecCert{
+				ClusterComponent: "calico",
+			},
+		},
+	}
+
+	if ClusterComponent(obj) != expectedClusterComponent {
+		t.Fatalf("clusterComponent %#q, want %s", ClusterComponent(obj), expectedClusterComponent)
+	}
+}

--- a/service/controller/v2/resources/vaultcrt/current.go
+++ b/service/controller/v2/resources/vaultcrt/current.go
@@ -50,7 +50,6 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	// draining was done and the pods got removed we get an empty list here after
 	// the delete event got replayed. Then we just remove the secrets as usual.
 	if key.IsDeleted(customObject) {
-
 		if !r.checkCertType(customObject) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "do not supporting this cert type any longer.")
 			return secret, nil

--- a/service/controller/v2/resources/vaultcrt/current.go
+++ b/service/controller/v2/resources/vaultcrt/current.go
@@ -53,7 +53,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		// If this customObject is not the cert we are supporting in certs library,
 		// we don't need to check for running pods.
 		if !r.checkCertType(customObject) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "unsupported cert type")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "unsupported cert type %#q", key.ClusterComponent(customObject))
 			return secret, nil
 		}
 
@@ -77,7 +77,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 // checkCertType checks whether customObject is one of the Cert types we are supporting in certs library.
 func (r *Resource) checkCertType(customObject v1alpha1.CertConfig) bool {
-	c := certs.Cert(customObject.Spec.Cert.ClusterComponent)
+	c := certs.Cert(key.ClusterComponent(customObject))
 	for _, cert := range certs.AllCerts {
 		if cert == c {
 			return true

--- a/service/controller/v2/resources/vaultcrt/current.go
+++ b/service/controller/v2/resources/vaultcrt/current.go
@@ -51,7 +51,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	// the delete event got replayed. Then we just remove the secrets as usual.
 	if key.IsDeleted(customObject) {
 		if !r.checkCertType(customObject) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "do not supporting this cert type any longer.")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "unsupported cert type")
 			return secret, nil
 		}
 

--- a/service/controller/v2/resources/vaultcrt/current.go
+++ b/service/controller/v2/resources/vaultcrt/current.go
@@ -50,6 +50,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	// draining was done and the pods got removed we get an empty list here after
 	// the delete event got replayed. Then we just remove the secrets as usual.
 	if key.IsDeleted(customObject) {
+		// If this customObject is not the cert we are supporting in certs library,
+		// we don't need to check for running pods.
 		if !r.checkCertType(customObject) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "unsupported cert type")
 			return secret, nil
@@ -73,6 +75,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	return secret, nil
 }
 
+// checkCertType checks whether customObject is one of the Cert types we are supporting in certs library.
 func (r *Resource) checkCertType(customObject v1alpha1.CertConfig) bool {
 	c := certs.Cert(customObject.Spec.Cert.ClusterComponent)
 	for _, cert := range certs.AllCerts {

--- a/service/controller/v2/resources/vaultcrt/current.go
+++ b/service/controller/v2/resources/vaultcrt/current.go
@@ -53,7 +53,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 		if !r.checkCertType(customObject) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "do not supporting this cert type any longer.")
-			return nil, nil
+			return secret, nil
 		}
 
 		n := key.ClusterNamespace(customObject)


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/6442

We will skip checking running pods on cluster namespace if only that `CertConfig` is not supporting any more.

In this particular PR, we are aiming for deletion of `calico` cert.