### PR TITLE
handle vault updates more graceful internally

### DIFF
--- a/service/collector/vault.go
+++ b/service/collector/vault.go
@@ -62,6 +62,7 @@ func (v *Vault) Collect(ch chan<- prometheus.Metric) error {
 	secret, err := v.vaultClient.Auth().Token().LookupSelf()
 	if IsVaultAccess(err) {
 		v.logger.LogCtx(ctx, "level", "debug", "message", "vault not reachable")
+		v.logger.LogCtx(ctx, "level", "debug", "message", "vault upgrade in progress")
 		v.logger.LogCtx(ctx, "level", "debug", "message", "canceling collection")
 		return nil
 

--- a/service/collector/vault.go
+++ b/service/collector/vault.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -56,8 +57,15 @@ func NewVault(config VaultConfig) (*Vault, error) {
 }
 
 func (v *Vault) Collect(ch chan<- prometheus.Metric) error {
+	ctx := context.Background()
+
 	secret, err := v.vaultClient.Auth().Token().LookupSelf()
-	if err != nil {
+	if IsVaultAccess(err) {
+		v.logger.LogCtx(ctx, "level", "debug", "message", "vault not reachable")
+		v.logger.LogCtx(ctx, "level", "debug", "message", "canceling collection")
+		return nil
+
+	} else if err != nil {
 		return microerror.Mask(err)
 	}
 

--- a/service/controller/cert.go
+++ b/service/controller/cert.go
@@ -52,34 +52,6 @@ func NewCert(config CertConfig) (*Cert, error) {
 	if config.G8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.G8sClient must not be empty")
 	}
-	if config.K8sClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
-	}
-	if config.K8sExtClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.K8sExtClient must not be empty")
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
-	}
-	if config.VaultClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.VaultClient must not be empty")
-	}
-
-	if config.CATTL == "" {
-		return nil, microerror.Maskf(invalidConfigError, "config.CATTL must not be empty")
-	}
-	if config.CommonNameFormat == "" {
-		return nil, microerror.Maskf(invalidConfigError, "config.CommonNameFormat must not be empty")
-	}
-	if config.ExpirationThreshold == 0 {
-		return nil, microerror.Maskf(invalidConfigError, "config.ExpirationThreshold must not be empty")
-	}
-	if config.Namespace == "" {
-		return nil, microerror.Maskf(invalidConfigError, "config.Namespace must not be empty")
-	}
-	if config.ProjectName == "" {
-		return nil, microerror.Maskf(invalidConfigError, "config.ProjectName must not be empty")
-	}
 
 	var err error
 
@@ -160,11 +132,12 @@ func NewCert(config CertConfig) (*Cert, error) {
 	var v2ResourceSet *controller.ResourceSet
 	{
 		c := v2.ResourceSetConfig{
-			K8sClient: config.K8sClient,
-			Logger:    config.Logger,
-			VaultCrt:  vaultCrt,
-			VaultPKI:  vaultPKI,
-			VaultRole: vaultRole,
+			K8sClient:   config.K8sClient,
+			Logger:      config.Logger,
+			VaultClient: config.VaultClient,
+			VaultCrt:    vaultCrt,
+			VaultPKI:    vaultPKI,
+			VaultRole:   vaultRole,
 
 			ExpirationThreshold: config.ExpirationThreshold,
 			Namespace:           config.Namespace,

--- a/service/controller/v2/resources/vaultaccess/create.go
+++ b/service/controller/v2/resources/vaultaccess/create.go
@@ -1,0 +1,23 @@
+package vaultaccess
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	_, err := r.vaultClient.Auth().Token().LookupSelf()
+	if IsVaultAccess(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "vault not reachable")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		return nil
+
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/v2/resources/vaultaccess/create.go
+++ b/service/controller/v2/resources/vaultaccess/create.go
@@ -11,6 +11,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	_, err := r.vaultClient.Auth().Token().LookupSelf()
 	if IsVaultAccess(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "vault not reachable")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "vault upgrade in progress")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 		reconciliationcanceledcontext.SetCanceled(ctx)
 		return nil

--- a/service/controller/v2/resources/vaultaccess/delete.go
+++ b/service/controller/v2/resources/vaultaccess/delete.go
@@ -1,0 +1,23 @@
+package vaultaccess
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	_, err := r.vaultClient.Auth().Token().LookupSelf()
+	if IsVaultAccess(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "vault not reachable")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		return nil
+
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/v2/resources/vaultaccess/delete.go
+++ b/service/controller/v2/resources/vaultaccess/delete.go
@@ -11,6 +11,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	_, err := r.vaultClient.Auth().Token().LookupSelf()
 	if IsVaultAccess(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "vault not reachable")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "vault upgrade in progress")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 		reconciliationcanceledcontext.SetCanceled(ctx)
 		return nil

--- a/service/controller/v2/resources/vaultaccess/error.go
+++ b/service/controller/v2/resources/vaultaccess/error.go
@@ -1,4 +1,4 @@
-package collector
+package vaultaccess
 
 import (
 	"strings"
@@ -34,7 +34,7 @@ var vaultAccessError = &microerror.Error{
 // IsVaultAccess asserts vaultAccessError. The matcher also asserts errors
 // caused by situations in which Vault is updated strategically and thus
 // temporarily replies with HTTP responses. In such cases we intend to cancel
-// collection and wait until Vault is fully operational again.
+// reconciliation and wait until Vault is fully operational again.
 //
 //     Get https://vault.g8s.amag.ch:8200/v1/sys/mounts: http: server gave HTTP response to HTTPS client
 //

--- a/service/controller/v2/resources/vaultaccess/resource.go
+++ b/service/controller/v2/resources/vaultaccess/resource.go
@@ -1,0 +1,41 @@
+package vaultaccess
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	vaultapi "github.com/hashicorp/vault/api"
+)
+
+const (
+	Name = "vaultaccessv2"
+)
+
+type Config struct {
+	Logger      micrologger.Logger
+	VaultClient *vaultapi.Client
+}
+
+type Resource struct {
+	logger      micrologger.Logger
+	vaultClient *vaultapi.Client
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.VaultClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.VaultClient must not be empty", config)
+	}
+
+	r := &Resource{
+		logger:      config.Logger,
+		vaultClient: config.VaultClient,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
When we update Vault on the control planes the operator throws a couple of errors which we should simply handle a bit more graceful. 

> {"caller":"github.com/giantswarm/cert-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource_ops_wrapper.go:71","controller":"cert-operator","event":"update","function":"GetCurrentState","level":"warning","loop":"91395","message":"retrying due to error","object":"/apis/core.giantswarm.io/v1alpha1/namespaces/default/certconfigs/sh0z0-app-operator-api","resource":"vaultpkiv2","stack":"[{/go/src/github.com/giantswarm/cert-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource_ops_wrapper.go:64: } {/go/src/github.com/giantswarm/cert-operator/service/controller/v2/resources/vaultpki/current.go:27: } {/go/src/github.com/giantswarm/cert-operator/vendor/github.com/giantswarm/vaultpki/current.go:37: } {Get https://vault.g8s.amag.ch:8200/v1/sys/mounts: http: server gave HTTP response to HTTPS client}]","time":"2019-08-12T11:27:05.792401+00:00","underlyingResource":"vaultpkiv2","version":"172692767"}