### PR TITLE
Cleaning certconfig belongs to deleted TCs

### DIFF
--- a/service/controller/cert.go
+++ b/service/controller/cert.go
@@ -132,6 +132,7 @@ func NewCert(config CertConfig) (*Cert, error) {
 	var v2ResourceSet *controller.ResourceSet
 	{
 		c := v2.ResourceSetConfig{
+			G8sClinet:   config.G8sClient,
 			K8sClient:   config.K8sClient,
 			Logger:      config.Logger,
 			VaultClient: config.VaultClient,

--- a/service/controller/v2/resource_set.go
+++ b/service/controller/v2/resource_set.go
@@ -43,6 +43,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var cleaningResource resource.Interface
 	{
 		c := cleaning.Config{
+			G8sClient: config.G8sClinet,
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 		}

--- a/service/controller/v2/resources/cleaning/create.go
+++ b/service/controller/v2/resources/cleaning/create.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -19,13 +18,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	clusterID := key.ClusterID(customObject)
-
-	if key.IsDeleted(customObject) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("certconfig %#q is going to be deleted", customObject.GetName()))
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
-		return nil
-	}
 
 	_, err = r.k8sClient.CoreV1().Namespaces().Get(clusterID, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {

--- a/service/controller/v2/resources/cleaning/create.go
+++ b/service/controller/v2/resources/cleaning/create.go
@@ -1,0 +1,45 @@
+package cleaning
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/cert-operator/service/controller/v2/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	clusterID := key.ClusterID(customObject)
+
+	if key.IsDeleted(customObject) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("certconfig %#q is going to be deleted", customObject.GetName()))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		return nil
+	}
+
+	_, err = r.k8sClient.CoreV1().Namespaces().Get(clusterID, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("cluster namespace %#q does not exist in CP", clusterID))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %#q certconfig", customObject.GetName()))
+
+		err = r.g8sClient.CoreV1alpha1().CertConfigs(customObject.GetNamespace()).Delete(customObject.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %#q certconfig", customObject.GetName()))
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/v2/resources/cleaning/create.go
+++ b/service/controller/v2/resources/cleaning/create.go
@@ -12,23 +12,23 @@ import (
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	customObject, err := key.ToCustomObject(obj)
+	cr, err := key.ToCustomObject(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	clusterID := key.ClusterID(customObject)
+	clusterID := key.ClusterID(cr)
 
 	_, err = r.k8sClient.CoreV1().Namespaces().Get(clusterID, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("cluster namespace %#q does not exist in CP", clusterID))
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %#q certconfig", customObject.GetName()))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting %#q certconfig", cr.GetName()))
 
-		err = r.g8sClient.CoreV1alpha1().CertConfigs(customObject.GetNamespace()).Delete(customObject.Name, &metav1.DeleteOptions{})
+		err = r.g8sClient.CoreV1alpha1().CertConfigs(cr.GetNamespace()).Delete(cr.Name, &metav1.DeleteOptions{})
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %#q certconfig", customObject.GetName()))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted %#q certconfig", cr.GetName()))
 	} else if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/v2/resources/cleaning/delete.go
+++ b/service/controller/v2/resources/cleaning/delete.go
@@ -3,5 +3,5 @@ package cleaning
 import "context"
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	panic("implement me")
+	return nil
 }

--- a/service/controller/v2/resources/cleaning/delete.go
+++ b/service/controller/v2/resources/cleaning/delete.go
@@ -1,0 +1,7 @@
+package cleaning
+
+import "context"
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	panic("implement me")
+}

--- a/service/controller/v2/resources/cleaning/error.go
+++ b/service/controller/v2/resources/cleaning/error.go
@@ -1,0 +1,12 @@
+package cleaning
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v2/resources/cleaning/resource.go
+++ b/service/controller/v2/resources/cleaning/resource.go
@@ -1,0 +1,50 @@
+package cleaning
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "cleaningv2"
+)
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+// Config represents the configuration used to create a new cleansing resource.
+type Config struct {
+	G8sClient versioned.Interface
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	g8sClient versioned.Interface
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		// Dependencies.
+		g8sClient: config.G8sClient,
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/7488

Deleting all remaining `certConfigs` by checking whether cluster namespace is deleted or not. 