### PR TITLE
Configure default image registry domain

### DIFF
--- a/helm/cert-operator-chart/values.yaml
+++ b/helm/cert-operator-chart/values.yaml
@@ -7,3 +7,8 @@ pspName: cert-operator-psp
 
 userID: 1000
 groupID: 1000
+
+Installation:
+  V1:
+    Registry:
+      Domain: quay.io


### PR DESCRIPTION
Via https://github.com/giantswarm/cert-operator/pull/231 image registry domain was made configurable, but no default value was set, and this broke e2e tests deploying cert-operator, like azure-operator I was testing https://github.com/giantswarm/azure-operator/pull/603

This PR configures `quay.io` as default image registry domain.