### PR TITLE
Template config struct into secret

### DIFF
--- a/helm/cert-operator-chart/templates/secret.yml
+++ b/helm/cert-operator-chart/templates/secret.yml
@@ -4,5 +4,8 @@ metadata:
   name: cert-operator-secret
   namespace: {{ .Values.namespace }}
 type: Opaque
-data:
-  secret.yaml: {{ .Values.Installation.V1.Secret.CertOperator.SecretYaml | b64enc | quote }}
+stringDate:
+  secret.yaml: |-
+    service:
+      vault:
+        token: {{ .Values.Installation.V1.Secret.CertOperator.Vault.Token }}

--- a/helm/cert-operator-chart/templates/secret.yml
+++ b/helm/cert-operator-chart/templates/secret.yml
@@ -8,4 +8,4 @@ stringDate:
   secret.yaml: |-
     service:
       vault:
-        token: {{ .Values.Installation.V1.Secret.CertOperator.Vault.Token }}
+        token: {{ .Values.Installation.V1.Secret.CertOperator.Service.Vault.Config.Token }}

--- a/helm/cert-operator-chart/templates/secret.yml
+++ b/helm/cert-operator-chart/templates/secret.yml
@@ -4,7 +4,7 @@ metadata:
   name: cert-operator-secret
   namespace: {{ .Values.namespace }}
 type: Opaque
-stringDate:
+stringData:
   secret.yaml: |-
     service:
       vault:

--- a/helm/cert-operator-chart/templates/secret.yml
+++ b/helm/cert-operator-chart/templates/secret.yml
@@ -8,4 +8,5 @@ stringData:
   secret.yaml: |-
     service:
       vault:
-        token: {{ .Values.Installation.V1.Secret.CertOperator.Service.Vault.Config.Token }}
+        config:
+          token: {{ .Values.Installation.V1.Secret.CertOperator.Service.Vault.Config.Token }}


### PR DESCRIPTION
Following https://github.com/giantswarm/opsctl/pull/552

As we still want to make it possible updating tokens with a single command, this change allows embedding just token instead of a whole yaml config from installation

Merging after updating installations repo