### PR TITLE
Revert "watch CR with cert-operator.giantswarm.io/version label (#272)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/giantswarm/vaultpki v0.2.0
 	github.com/giantswarm/vaultrole v0.2.0
 	github.com/giantswarm/versionbundle v0.2.0
-	github.com/google/go-cmp v0.4.0
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/prometheus/client_golang v1.5.1
 	github.com/spf13/viper v1.6.2

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -1,8 +1,5 @@
 package label
 
 const (
-	Cluster         = "giantswarm.io/cluster"
-	OperatorVersion = "cert-operator.giantswarm.io/version"
-	// ManagedByLabel is used to flag resources create by this operator.
-	ManagedByLabel = "giantswarm.io/managed-by"
+	Cluster = "giantswarm.io/cluster"
 )

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -8,9 +8,6 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/certs"
 	"github.com/giantswarm/microerror"
-
-	"github.com/giantswarm/cert-operator/pkg/label"
-	"github.com/giantswarm/cert-operator/pkg/project"
 )
 
 const (
@@ -87,11 +84,7 @@ func SecretName(customObject v1alpha1.CertConfig) string {
 
 func SecretLabels(customObject v1alpha1.CertConfig) map[string]string {
 	cert := certs.Cert(customObject.Spec.Cert.ClusterComponent)
-	labels := certs.K8sLabels(ClusterID(customObject), cert)
-
-	labels[label.ManagedByLabel] = project.Name()
-
-	return labels
+	return certs.K8sLabels(ClusterID(customObject), cert)
 }
 
 func ToCustomObject(v interface{}) (v1alpha1.CertConfig, error) {
@@ -104,6 +97,6 @@ func ToCustomObject(v interface{}) (v1alpha1.CertConfig, error) {
 	return customObject, nil
 }
 
-func OperatorVersion(getter LabelsGetter) string {
-	return getter.GetLabels()[label.OperatorVersion]
+func VersionBundleVersion(customObject v1alpha1.CertConfig) string {
+	return customObject.Spec.VersionBundle.Version
 }

--- a/service/controller/key/spec.go
+++ b/service/controller/key/spec.go
@@ -1,5 +1,0 @@
-package key
-
-type LabelsGetter interface {
-	GetLabels() map[string]string
-}

--- a/service/controller/resource_set.go
+++ b/service/controller/resource_set.go
@@ -145,7 +145,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			return false
 		}
 
-		if key.OperatorVersion(&cr) == project.Version() {
+		if key.VersionBundleVersion(cr) == project.NewVersionBundle().Version {
 			return true
 		}
 

--- a/service/controller/resources/vaultcrt/desired.go
+++ b/service/controller/resources/vaultcrt/desired.go
@@ -31,8 +31,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		ObjectMeta: apismetav1.ObjectMeta{
 			Name: key.SecretName(customObject),
 			Annotations: map[string]string{
-				ConfigHashAnnotation:      hash,
-				UpdateTimestampAnnotation: r.currentTimeFactory().In(time.UTC).Format(UpdateTimestampLayout),
+				ConfigHashAnnotation:           hash,
+				UpdateTimestampAnnotation:      r.currentTimeFactory().In(time.UTC).Format(UpdateTimestampLayout),
+				VersionBundleVersionAnnotation: key.VersionBundleVersion(customObject),
 			},
 			Labels: key.SecretLabels(customObject),
 		},

--- a/service/controller/resources/vaultcrt/desired_test.go
+++ b/service/controller/resources/vaultcrt/desired_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
 	"github.com/giantswarm/vaultcrt/vaultcrttest"
-	"github.com/google/go-cmp/cmp"
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -37,15 +36,15 @@ func Test_Resource_VaultCrt_GetDesiredState(t *testing.T) {
 				ObjectMeta: apismetav1.ObjectMeta{
 					Name: "foobar-api",
 					Annotations: map[string]string{
-						ConfigHashAnnotation:      "394f594f5cf6a2deb9abc6f0e322d887557d4a8e",
-						UpdateTimestampAnnotation: (time.Time{}).Format(UpdateTimestampLayout),
+						ConfigHashAnnotation:           "394f594f5cf6a2deb9abc6f0e322d887557d4a8e",
+						UpdateTimestampAnnotation:      (time.Time{}).Format(UpdateTimestampLayout),
+						VersionBundleVersionAnnotation: "0.1.0",
 					},
 					Labels: map[string]string{
 						"clusterID":                 "foobar",
 						"clusterComponent":          "api",
 						"giantswarm.io/cluster":     "foobar",
 						"giantswarm.io/certificate": "api",
-						"giantswarm.io/managed-by":  "cert-operator",
 					},
 				},
 				StringData: map[string]string{
@@ -73,15 +72,15 @@ func Test_Resource_VaultCrt_GetDesiredState(t *testing.T) {
 				ObjectMeta: apismetav1.ObjectMeta{
 					Name: "al9qy-worker",
 					Annotations: map[string]string{
-						ConfigHashAnnotation:      "d240dfb0f9dc171ce6dda44b0e55227896247cb9",
-						UpdateTimestampAnnotation: (time.Time{}).Format(UpdateTimestampLayout),
+						ConfigHashAnnotation:           "d240dfb0f9dc171ce6dda44b0e55227896247cb9",
+						UpdateTimestampAnnotation:      (time.Time{}).Format(UpdateTimestampLayout),
+						VersionBundleVersionAnnotation: "0.2.0",
 					},
 					Labels: map[string]string{
 						"clusterID":                 "al9qy",
 						"clusterComponent":          "worker",
 						"giantswarm.io/cluster":     "al9qy",
 						"giantswarm.io/certificate": "worker",
-						"giantswarm.io/managed-by":  "cert-operator",
 					},
 				},
 				StringData: map[string]string{
@@ -119,7 +118,7 @@ func Test_Resource_VaultCrt_GetDesiredState(t *testing.T) {
 		}
 		secret := result.(*apiv1.Secret)
 		if !reflect.DeepEqual(tc.ExpectedSecret, secret) {
-			t.Fatalf("case %d unexpected result\n%s", i, cmp.Diff(tc.ExpectedSecret, secret))
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedSecret, secret)
 		}
 	}
 }

--- a/service/controller/resources/vaultcrt/metric.go
+++ b/service/controller/resources/vaultcrt/metric.go
@@ -1,0 +1,25 @@
+package vaultcrt
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	PrometheusNamespace            = "cert_operator"
+	PrometheusSubsystem            = "vaultcrt_resource"
+	VersionBundleVersionAnnotation = "giantswarm.io/version-bundle-version"
+)
+
+var versionBundleVersionGauge = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: PrometheusNamespace,
+		Subsystem: PrometheusSubsystem,
+		Name:      "version_bundle_version_total",
+		Help:      "A metric labeled by major, minor and patch version of the version bundle being in use.",
+	},
+	[]string{"major", "minor", "patch"},
+)
+
+func init() {
+	prometheus.MustRegister(versionBundleVersionGauge)
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/9343

This reverts PR https://github.com/giantswarm/cert-operator/pull/272

We can't switch to watching with labels because we still have lot of
CertConfig CR which do not have this label and we need to reconcile
those.


## Checklist

- [ ] Update changelog in CHANGELOG.md.