### PR TITLE
release 0.1.0

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "cert-operator"
 	source      string = "https://github.com/giantswarm/cert-operator"
-	version            = "1.0.1-dev"
+	version            = "0.1.0"
 )
 
 func Description() string {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/10389

Set version to `0.1.0` which is the current version of cert-operator.


## Checklist

- [ ] Update changelog in CHANGELOG.md.