### PR TITLE
Prepare retag of 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] 2020-05-15
+
 ### Changed
 
 - No longer ensure CertConfig CRD.
 - Use architect-orb to release cert-operator.
-- Migrated to unique app deployment.
-
-## [0.1.0] 2020-03-20
 
 ### Added
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*    @giantswarm/team-ludacris

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,2 +1,0 @@
-Ross Fairbanks <ross@giantswarm.io> (@rossf7) pkg:*
-# TODO: Add backup

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "cert-operator"
 	source      string = "https://github.com/giantswarm/cert-operator"
-	version            = "0.1.0-dev"
+	version            = "0.1.0"
 )
 
 func Description() string {


### PR DESCRIPTION
Some changelog entries were untrue. This will be tagged as `0.1.0.1` which reconciles `0.1.0` still. This is necessary to include the `CRD` changed (mainly no longer ensuring the CRD) with version `0.1.0`.

## Checklist

- [x] Update changelog in CHANGELOG.md.
