### PR TITLE
Bring back version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `apiextensions` to `0.4.1` version.
+- Set version `0.1.0` in `project.go`.
 
 ## [0.1.0-1] - 2020-08-07
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "cert-operator"
 	source      string = "https://github.com/giantswarm/cert-operator"
-	version            = "0.1.0-1"
+	version            = "0.1.0"
 )
 
 func Description() string {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12653

Version like `0.1.0-1`, which are expected to replace e.g. `0.1.0`, should not be set in `project.go`

## Checklist

- [x] Update changelog in CHANGELOG.md.
