### PR TITLE
Add list for clusters

### DIFF
--- a/helm/cert-operator/templates/rbac.yaml
+++ b/helm/cert-operator/templates/rbac.yaml
@@ -36,6 +36,7 @@ rules:
       - clusters
     verbs:
       - get
+      - list
   - apiGroups:
       - provider.giantswarm.io
     resources:


### PR DESCRIPTION
This somehow became necessary between starting the 1.0.0 release PR and the release itself, possibly related to management cluster version upgrade or https://github.com/giantswarm/cert-operator/pull/330.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
