### PR TITLE
Use separate CA for etcd certificates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ workflows:
           app_catalog_test: "control-plane-test-catalog"
           chart: "cert-operator"
           requires:
-            - push-cert-operator-to-aliyun
             - push-cert-operator-to-quay
           filters:
             tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Create separate PKI engine for etcd.
+
 ## [1.0.1] - 2021-02-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Create separate PKI engine for etcd.
+- Use etcd PKI engine for etcd certificates.
 
 ## [1.0.1] - 2021-02-23
 

--- a/go.mod
+++ b/go.mod
@@ -29,5 +29,6 @@ require (
 replace (
 	github.com/coreos/etcd v3.3.10+incompatible => github.com/coreos/etcd v3.3.24+incompatible
 	github.com/coreos/etcd v3.3.13+incompatible => github.com/coreos/etcd v3.3.24+incompatible
+	github.com/gogo/protobuf v1.3.1 => github.com/gogo/protobuf v1.3.2
 	sigs.k8s.io/cluster-api => github.com/giantswarm/cluster-api v0.3.13-gs
 )

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
-github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
-github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
+github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -449,6 +449,7 @@ github.com/kataras/pio v0.0.2/go.mod h1:hAoW0t9UmXi4R5Oyq5Z4irTbaTsOemSrDGUtaTl7
 github.com/kataras/sitemap v0.0.5/go.mod h1:KY2eugMKiPwsJgx7+U103YZehfvNGOXURubcGyk0Bz8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
+github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.8.2/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.9.7/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
@@ -717,6 +718,8 @@ github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmv
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZkTdatxwunjIkc=
+github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
@@ -780,6 +783,9 @@ golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCc
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
+golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -807,6 +813,7 @@ golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
@@ -822,6 +829,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -910,8 +918,11 @@ golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200103221440-774c71fcf114 h1:DnSr2mCsxyCE6ZgIkmcWUQY2R5cH/6wL7eIxEmQOMSE=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20210106214847-113979e3529a h1:CB3a9Nez8M13wwlr/E2YtwoU+qYHKfC+JrDa45RXXoQ=
+golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/service/controller/cert.go
+++ b/service/controller/cert.go
@@ -169,7 +169,7 @@ func cleanupPKIBackends(logger micrologger.Logger, k8sClient k8sclient.Interface
 		}
 
 		if !exists {
-			logger.Log("level", "debug", "message", fmt.Sprintf("deleting PKI backend for Tenant Cluster %#q", id))
+			logger.Log("level", "debug", "message", fmt.Sprintf("deleting PKI backends for Tenant Cluster %#q", id))
 
 			{
 				err := k8sClient.CtrlClient().DeleteAllOf(
@@ -192,7 +192,14 @@ func cleanupPKIBackends(logger micrologger.Logger, k8sClient k8sclient.Interface
 				}
 			}
 
-			logger.Log("level", "debug", "message", fmt.Sprintf("deleted PKI backend for Tenant Cluster %#q", id))
+			{
+				err := vaultPKI.DeleteBackend(fmt.Sprintf("%s-etcd", id))
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+
+			logger.Log("level", "debug", "message", fmt.Sprintf("deleted PKI backends for Tenant Cluster %#q", id))
 		}
 	}
 

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -73,6 +73,15 @@ func Organizations(customObject v1alpha1.CertConfig) []string {
 	return append(a, customObject.Spec.Cert.Organizations...)
 }
 
+func PKIIdsForCluster(clusterID string) []string {
+	ids := []string{
+		clusterID,
+		fmt.Sprintf("%s-etcd", clusterID),
+	}
+
+	return ids
+}
+
 func RoleTTL(customObject v1alpha1.CertConfig) string {
 	return customObject.Spec.Cert.TTL
 }

--- a/service/controller/resources/vaultcrt/resource.go
+++ b/service/controller/resources/vaultcrt/resource.go
@@ -115,12 +115,6 @@ func (r *Resource) issueCertificate(customObject v1alpha1.CertConfig) (string, s
 		case string(certs.Etcd2Cert):
 			fallthrough
 		case string(certs.Etcd3Cert):
-			fallthrough
-		case string(certs.CalicoEtcdClientCert):
-			fallthrough
-		case string(certs.FlanneldEtcdClientCert):
-			fallthrough
-		case string(certs.PrometheusEtcdClientCert):
 			pkiID = fmt.Sprintf("%s-etcd", key.ClusterID(customObject))
 		default:
 			pkiID = key.ClusterID(customObject)

--- a/service/controller/resources/vaultpki/create.go
+++ b/service/controller/resources/vaultpki/create.go
@@ -20,23 +20,21 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	}
 
 	if vaultPKIStateToCreate.Backend != nil {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the Vault PKI in the Vault API")
-
-		err := r.vaultPKI.CreateBackend(key.ClusterID(customObject))
-		if err != nil {
-			return microerror.Mask(err)
+		ids := []string{
+			key.ClusterID(customObject),
+			fmt.Sprintf("%s-etcd", key.ClusterID(customObject)),
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "created the Vault PKI in the Vault API")
+		for _, id := range ids {
+			r.logger.Debugf(ctx, "creating the Vault PKI %s in the Vault API", id)
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the etcd Vault PKI in the Vault API")
+			err := r.vaultPKI.CreateBackend(id)
+			if err != nil {
+				return microerror.Mask(err)
+			}
 
-		err = r.vaultPKI.CreateBackend(fmt.Sprintf("%s-etcd", key.ClusterID(customObject)))
-		if err != nil {
-			return microerror.Mask(err)
+			r.logger.Debugf(ctx, "created the Vault PKI %s in the Vault API", id)
 		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", "created the etcd Vault PKI in the Vault API")
 	} else {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "the Vault PKI does not need to be created in the Vault API")
 	}

--- a/service/controller/resources/vaultpki/create.go
+++ b/service/controller/resources/vaultpki/create.go
@@ -2,7 +2,6 @@ package vaultpki
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/microerror"
 
@@ -19,10 +18,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		return microerror.Mask(err)
 	}
 
-	ids := []string{
-		key.ClusterID(customObject),
-		fmt.Sprintf("%s-etcd", key.ClusterID(customObject)),
-	}
+	ids := key.PKIIdsForCluster(key.ClusterID(customObject))
 
 	if vaultPKIStateToCreate.Backend != nil {
 		for _, id := range ids {

--- a/service/controller/resources/vaultpki/create.go
+++ b/service/controller/resources/vaultpki/create.go
@@ -2,6 +2,7 @@ package vaultpki
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/giantswarm/microerror"
 
@@ -27,6 +28,15 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		}
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "created the Vault PKI in the Vault API")
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the etcd Vault PKI in the Vault API")
+
+		err = r.vaultPKI.CreateBackend(fmt.Sprintf("%s-etcd", key.ClusterID(customObject)))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created the etcd Vault PKI in the Vault API")
 	} else {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "the Vault PKI does not need to be created in the Vault API")
 	}
@@ -40,6 +50,16 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		}
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "created the root CA in the Vault PKI")
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the etcd root CA in the Vault PKI")
+
+		_, err = r.vaultPKI.CreateCA(key.ClusterID(customObject))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created the etcd root CA in the Vault PKI")
+
 	} else {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "the root CA does not need to be created in the Vault PKI")
 	}

--- a/service/controller/resources/vaultpki/delete.go
+++ b/service/controller/resources/vaultpki/delete.go
@@ -2,6 +2,7 @@ package vaultpki
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/v4/pkg/resource/crud"
@@ -32,16 +33,23 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	}
 
 	if vaultPKIStateToDelete.Backend != nil || vaultPKIStateToDelete.CACertificate != "" {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the Vault PKI in the Vault API")
-
-		err := r.vaultPKI.DeleteBackend(key.ClusterID(customObject))
-		if err != nil {
-			return microerror.Mask(err)
+		ids := []string{
+			key.ClusterID(customObject),
+			fmt.Sprintf("%s-etcd", key.ClusterID(customObject)),
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the Vault PKI in the Vault API")
+		for _, id := range ids {
+			r.logger.Debugf(ctx, "deleting the Vault PKI %s in the Vault API", id)
+
+			err := r.vaultPKI.DeleteBackend(id)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.Debugf(ctx, "deleted the Vault PKI %s in the Vault API", id)
+		}
 	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "the Vault PKI does not need to be deleted from the Vault API")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the Vault PKIs does not need to be deleted from the Vault API")
 	}
 
 	return nil

--- a/service/controller/resources/vaultpki/delete.go
+++ b/service/controller/resources/vaultpki/delete.go
@@ -2,7 +2,6 @@ package vaultpki
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/v4/pkg/resource/crud"
@@ -33,10 +32,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	}
 
 	if vaultPKIStateToDelete.Backend != nil || vaultPKIStateToDelete.CACertificate != "" {
-		ids := []string{
-			key.ClusterID(customObject),
-			fmt.Sprintf("%s-etcd", key.ClusterID(customObject)),
-		}
+		ids := key.PKIIdsForCluster(key.ClusterID(customObject))
 
 		for _, id := range ids {
 			r.logger.Debugf(ctx, "deleting the Vault PKI %s in the Vault API", id)

--- a/service/controller/resources/vaultrole/create.go
+++ b/service/controller/resources/vaultrole/create.go
@@ -2,10 +2,11 @@ package vaultrole
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/vaultrole"
+
+	"github.com/giantswarm/cert-operator/service/controller/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
@@ -15,11 +16,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	}
 
 	if roleToCreate != nil {
-		ids := []string{
-			roleToCreate.ID,
-			fmt.Sprintf("%s-etcd", roleToCreate.ID),
-		}
-
+		ids := key.PKIIdsForCluster(roleToCreate.ID)
 		for _, id := range ids {
 			r.logger.Debugf(ctx, "creating the role in the Vault API for PKI %s", id)
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/16494

The goal of this PR is to create a separate PKI on `vault` to be used for etcd certificates.
This is a security best practice that is used by kubeadm.

I agree we could probably find more elegant ways of developing this feature, but implemented like this is 100% transparent for cluster operator and the provider operators.

Do you think this is a viable solution?

## Checklist

- [x] Update changelog in CHANGELOG.md.

