### PR TITLE
introduce v1alpha3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Introducing `v1alpha3` CR's.
+
 ### Added
 
 - Add check to ensure that the `Cluster` resource is in the same namespace as the `certConfig` before creating the secret there.

--- a/helm/cert-operator/templates/rbac.yaml
+++ b/helm/cert-operator/templates/rbac.yaml
@@ -40,7 +40,6 @@ rules:
   - apiGroups:
       - provider.giantswarm.io
     resources:
-      - awsconfigs
       - azureconfigs
       - kvmconfigs
     verbs:

--- a/service/controller/cert.go
+++ b/service/controller/cert.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/cert-operator/pkg/label"
@@ -206,7 +206,7 @@ func tenantClusterExists(k8sClient k8sclient.Interface, id string) (bool, error)
 	// We need to check for Node Pools clusters. These adhere to CAPI and do not
 	// have any AWSConfig CR anymore.
 	{
-		crs := &apiv1alpha2.ClusterList{}
+		crs := &apiv1alpha3.ClusterList{}
 
 		var labelSelector client.MatchingLabels
 		{
@@ -223,20 +223,6 @@ func tenantClusterExists(k8sClient k8sclient.Interface, id string) (bool, error)
 			return false, microerror.Mask(err)
 		} else if len(crs.Items) < 1 {
 			// fall through
-		} else {
-			return true, nil
-		}
-	}
-
-	// We need to check for the legacy AWSConfig CRs on AWS environments.
-	{
-		err = k8sClient.CtrlClient().Get(context.Background(), types.NamespacedName{Name: id, Namespace: corev1.NamespaceDefault}, &providerv1alpha1.AWSConfig{})
-		if errors.IsNotFound(err) {
-			// fall through
-		} else if IsNoKind(err) {
-			// fall through
-		} else if err != nil {
-			return false, microerror.Mask(err)
 		} else {
 			return true, nil
 		}

--- a/service/controller/resources/vaultcrt/create.go
+++ b/service/controller/resources/vaultcrt/create.go
@@ -8,7 +8,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/giantswarm/cert-operator/service/controller/key"
 )
@@ -26,7 +26,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		}
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", "finding cluster resource")
-		cluster := &apiv1alpha2.Cluster{}
+		cluster := &apiv1alpha3.Cluster{}
 		err = r.ctrlClient.Get(ctx, types.NamespacedName{
 			Namespace: customObject.Namespace,
 			Name:      key.ClusterID(customObject)},

--- a/service/controller/resources/vaultcrt/create_test.go
+++ b/service/controller/resources/vaultcrt/create_test.go
@@ -13,7 +13,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
-	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	fakectrl "sigs.k8s.io/controller-runtime/pkg/client/fake" //nolint:staticcheck // v0.6.4 has a deprecation on pkg/client/fake that was removed in later versions
 )
 
@@ -115,7 +115,7 @@ func Test_Resource_VaultCrt_newCreateChange(t *testing.T) {
 	{
 		c := DefaultConfig()
 		scheme := runtime.NewScheme()
-		_ = apiv1alpha2.AddToScheme(scheme)
+		_ = apiv1alpha3.AddToScheme(scheme)
 
 		c.CurrentTimeFactory = func() time.Time { return time.Time{} }
 		c.K8sClient = fake.NewSimpleClientset()

--- a/service/controller/resources/vaultcrt/delete_test.go
+++ b/service/controller/resources/vaultcrt/delete_test.go
@@ -13,7 +13,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
-	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	fakectrl "sigs.k8s.io/controller-runtime/pkg/client/fake" //nolint:staticcheck // v0.6.4 has a deprecation on pkg/client/fake that was removed in later versions
 )
 
@@ -99,7 +99,7 @@ func Test_Resource_VaultCrt_newDeleteChange(t *testing.T) {
 	{
 		c := DefaultConfig()
 		scheme := runtime.NewScheme()
-		_ = apiv1alpha2.AddToScheme(scheme)
+		_ = apiv1alpha3.AddToScheme(scheme)
 
 		c.CurrentTimeFactory = func() time.Time { return time.Time{} }
 		c.K8sClient = fake.NewSimpleClientset()

--- a/service/controller/resources/vaultcrt/desired_test.go
+++ b/service/controller/resources/vaultcrt/desired_test.go
@@ -13,7 +13,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
-	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	fakectrl "sigs.k8s.io/controller-runtime/pkg/client/fake" //nolint:staticcheck // v0.6.4 has a deprecation on pkg/client/fake that was removed in later versions
 
 	"github.com/giantswarm/cert-operator/pkg/project"
@@ -102,7 +102,7 @@ func Test_Resource_VaultCrt_GetDesiredState(t *testing.T) {
 	{
 		c := DefaultConfig()
 		scheme := runtime.NewScheme()
-		_ = apiv1alpha2.AddToScheme(scheme)
+		_ = apiv1alpha3.AddToScheme(scheme)
 
 		c.CurrentTimeFactory = func() time.Time { return time.Time{} }
 		c.K8sClient = fake.NewSimpleClientset()

--- a/service/controller/resources/vaultcrt/update_test.go
+++ b/service/controller/resources/vaultcrt/update_test.go
@@ -12,7 +12,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
-	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	fakectrl "sigs.k8s.io/controller-runtime/pkg/client/fake" //nolint:staticcheck // v0.6.4 has a deprecation on pkg/client/fake that was removed in later versions
 )
 
@@ -339,7 +339,7 @@ func Test_Resource_VaultCrt_shouldCertBeRenewed_expiration(t *testing.T) {
 		{
 			c := DefaultConfig()
 			scheme := runtime.NewScheme()
-			_ = apiv1alpha2.AddToScheme(scheme)
+			_ = apiv1alpha3.AddToScheme(scheme)
 
 			c.CurrentTimeFactory = func() time.Time { return tc.CurrentTime }
 			c.K8sClient = fake.NewSimpleClientset()
@@ -525,7 +525,7 @@ func Test_Resource_VaultCrt_shouldCertBeRenewed_hash(t *testing.T) {
 		{
 			c := DefaultConfig()
 			scheme := runtime.NewScheme()
-			_ = apiv1alpha2.AddToScheme(scheme)
+			_ = apiv1alpha3.AddToScheme(scheme)
 
 			c.CurrentTimeFactory = func() time.Time { return time.Time{} }
 			c.K8sClient = fake.NewSimpleClientset()

--- a/service/service.go
+++ b/service/service.go
@@ -16,7 +16,7 @@ import (
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/rest"
-	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	apiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	clientvault "github.com/giantswarm/cert-operator/client/vault"
 	"github.com/giantswarm/cert-operator/flag"
@@ -83,7 +83,7 @@ func New(config Config) (*Service, error) {
 	{
 		c := k8sclient.ClientsConfig{
 			SchemeBuilder: k8sclient.SchemeBuilder{
-				apiv1alpha2.AddToScheme,
+				apiv1alpha3.AddToScheme,
 				corev1alpha1.AddToScheme,
 				providerv1alpha1.AddToScheme,
 			},


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/494
We want to move to v1alpha3 so that this new version also works for azure and will still work for aws in the future.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
