### PR TITLE
Renew token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `RenewSelf` instead of `LookupSelf` to prevent expiration of `Vault token`.
+
 ## [1.2.0] - 2021-10-15
 
 ### Changed

--- a/service/controller/resources/vaultaccess/create.go
+++ b/service/controller/resources/vaultaccess/create.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	_, err := r.vaultClient.Auth().Token().LookupSelf()
+	_, err := r.vaultClient.Auth().Token().RenewSelf(0)
 	if IsVaultAccess(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "vault not reachable")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "vault upgrade in progress")

--- a/service/controller/resources/vaultaccess/create.go
+++ b/service/controller/resources/vaultaccess/create.go
@@ -8,6 +8,7 @@ import (
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "renewing the Vault token")
 	_, err := r.vaultClient.Auth().Token().RenewSelf(0)
 	if IsVaultAccess(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "vault not reachable")
@@ -19,6 +20,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
+	r.logger.LogCtx(ctx, "level", "debug", "message", "renewed the Vault token")
 
 	return nil
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/660 and https://github.com/giantswarm/roadmap/issues/657

This PR makes cert-operator renew its vault token at every reconciliation loop to prevent it from expiring

## Checklist

- [x] Update changelog in CHANGELOG.md.
