### PR TITLE
Allow running unique and non unique cert-operators in the same namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow running unique and non unique cert-operators in the same namespace.
+
 ## [3.0.0] - 2022-11-23
 
 ### Added

--- a/helm/cert-operator/templates/_helpers.tpl
+++ b/helm/cert-operator/templates/_helpers.tpl
@@ -22,7 +22,7 @@ app: {{ include "name" . | quote }}
 app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: "{{ .Chart.AppVersion }}{{- if eq $.Chart.Name $.Release.Name }}-unique{{ end }}"
 helm.sh/chart: {{ include "chart" . | quote }}
 {{- end -}}
 


### PR DESCRIPTION
Since v3.0.0, cert-operator may also run as a unique app as well as a release app.
Both deployment styles of the app end up in the same namespace (giantswarm) so it might be that two versions (in terms of project version) of cert-operator are deployed in the same namespace.
In order to avoid a conflict and helm refusing to install the app, we need to change the labels in order to distinguish between a unique and a non unique app.

This PR does just that

## Checklist

- [x] Update changelog in CHANGELOG.md.
