### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `global.podSecurityStandards.enforced` value for PSS migration.
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [3.2.1] - 2023-08-03
 
 ### Fixed

--- a/helm/cert-operator/values.yaml
+++ b/helm/cert-operator/values.yaml
@@ -14,7 +14,7 @@ k8sJwtToVaultTokenImage:
   tag: 0.1.0
 
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 resource:
   expirationThreshold: "2160h"
@@ -46,12 +46,12 @@ securityContext:
       type: RuntimeDefault
     capabilities:
       drop:
-      - ALL
+        - ALL
   initContainers:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
+        - ALL
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
