### PR TITLE
Avoid exiting with a failure at startup time if the PKI cleanup fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Avoid exiting with a failure at startup time if the PKI cleanup fails.
+
 ## [3.3.0] - 2024-03-26
 
 ### Added


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30400

With this PR, any errors in the cleanup phase of unused PKIs won't prevent the operator from running but just warn

## Checklist

- [x] Update changelog in CHANGELOG.md.
